### PR TITLE
feat: dockerize shadowhound

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+output/
+logo.png
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+output/results.txt
+output/test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use PowerShell base image with specific version
+FROM mcr.microsoft.com/powershell:7.2-ubuntu-20.04
+
+# Set working directory
+WORKDIR /app
+
+# Copy scripts
+COPY ShadowHound-ADM.ps1 /app/
+COPY ShadowHound-DS.ps1 /app/
+COPY split_output.py /app/
+
+# Install required PowerShell modules
+SHELL ["pwsh", "-Command"]
+RUN $ProgressPreference = 'SilentlyContinue' && \
+    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted && \
+    Install-Module -Name ActiveDirectory -Force -SkipPublisherCheck -AllowClobber -Confirm:$false
+
+# Switch back to sh for apt commands
+SHELL ["/bin/sh", "-c"]
+# Install Python for split_output.py
+RUN apt-get update && \
+    apt-get install -y python3 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create volume for output
+VOLUME /output
+
+# Set default command
+ENTRYPOINT [ "pwsh" ]


### PR DESCRIPTION
thanks for the awesome project! are you guys opening to adding this to a docker container usage example? i'd like to run this from a containerized environment

```markdown
# ShadowHound Docker Usage Guide

## Setup

Build the Docker image:

$ docker build --platform linux/arm64 -t shadowhound .

Create output directory

$ mkdir -p output
$ chmod 777 output

## Basic Usage

### Standard Domain Enumeration

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; ShadowHound-ADM -OutputFilePath '/output/results.txt'"

### Specify Domain Controller

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; ShadowHound-ADM -Server 'your.domain.com' -OutputFilePath '/output/results.txt'"

### Certificate Enumeration

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; ShadowHound-ADM -Certificates -OutputFilePath '/output/certs.txt'"

### Large Domain Enumeration

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; ShadowHound-ADM -SplitSearch -LetterSplitSearch -OutputFilePath '/output/large_domain.txt'"

## Command Options Explained

- `-it`: Interactive mode with terminal
- `--rm`: Remove container after exit
- `--platform linux/arm64`: Specify platform (for M1/M2 Macs)
- `-v $(pwd)/output:/output`: Mount local output directory to container
- `-Command`: Execute PowerShell command

## Advanced Usage

### With Custom LDAP Filter

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; ShadowHound-ADM -OutputFilePath '/output/results.txt' -LdapFilter '(objectClass=user)'"

### With Specific Search Base

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; ShadowHound-ADM -OutputFilePath '/output/results.txt' -SearchBase 'DC=domain,DC=local'"

### With Alternative Credentials

docker run -it --rm --platform linux/arm64 \
-v $(pwd)/output:/output \
shadowhound -Command ". /app/ShadowHound-ADM.ps1; $cred = Get-Credential; ShadowHound-ADM -OutputFilePath '/output/results.txt' -Credential $cred"

## Troubleshooting

### Check Container Status

$ docker ps | grep shadowhound

### View container logs

$ docker logs $(docker ps -q --filter ancestor=shadowhound)

### Enter Container for Debugging

$ docker run -it --rm --platform linux/arm64 shadowhound
```

## Notes
- All output files will be saved in the local `output` directory
- Make sure the output directory exists and has proper permissions
- For Windows PowerShell, replace `$(pwd)` with `${PWD}` in the volume mount
