### PR TITLE
Resumable Enumeration and 3-Letter Splitting to ShadowHound-ADM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Test outputs and state files
+*.txt
+*.state.json
+
+# Documentation except README
+*.md
+!README.md
+
+# Keep split_output.py
+!split_output.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.txt
 *.state.json
 
-# Documentation except README
+# Tooling/config (local only)
+.github/
+
 *.md
 !README.md
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Huge thanks to [Itay Yashar](https://www.linkedin.com/in/itay-yashar-55586a163/)
 - **Features**:
   - Handles large domains with `-SplitSearch`, `-Recurse`, and `-LetterSplitSearch` options.
   - Enumerates certificates with the `-Certificates` flag.
+  - **Resumable enumeration** - Automatic checkpointing that survives interruptions.
+  - **3-letter splitting** - Handles dense prefixes that timeout at 2-letter level.
 
 ### ShadowHound-DS.ps1
 
@@ -84,6 +86,28 @@ ShadowHound-ADM -OutputFilePath "C:\Results\ldap_output.txt" -SplitSearch -Lette
 - **`-SplitSearch`**: Splits the search across top-level containers.
 - **`-Recurse`**: Recurses into containers that fail to return results.
 - **`-LetterSplitSearch`**: Further splits searches by the first letter of CN.
+
+### Resumable Enumeration (ShadowHound-ADM.ps1)
+
+Enumeration automatically saves progress. If interrupted (network drop, Ctrl+C, session killed), just run the same command again - it picks up where it left off.
+
+```powershell
+# Start enumeration
+ShadowHound-ADM -Server dc.corp.local -OutputFilePath output.txt -LetterSplitSearch
+
+# Gets interrupted...
+
+# Resume automatically
+ShadowHound-ADM -Server dc.corp.local -OutputFilePath output.txt -LetterSplitSearch
+```
+
+**New parameters:**
+- **`-DisableStateFile`**: No checkpoints (OPSEC - no artifacts)
+- **`-StartFromLetter <char>`**: Skip ahead (e.g. `-StartFromLetter "m"`)
+- **`-KeepStateFile`**: Preserve state file after completion
+- **`-StateFile <path>`**: Custom state file location
+
+For more details on resumable enumeration and 3-letter splitting, see the [feature PR](https://github.com/Friends-Security/ShadowHound/pull/XX).
 
 ## Converting Data for BloodHound
 

--- a/README.md
+++ b/README.md
@@ -114,18 +114,17 @@ For more details on resumable enumeration and 3-letter splitting, see the [featu
 If the ldap_output.txt you got using ShadowHound is too large for Bofhound (Memory error), you may split the ShadowHound output using split_output.py:
 ```bash
 # Split ldap_output.txt to 100 chunks which are named split_output_1.txt, split_output_2.txt and so on...
-# In order to provide bofhound with a folder containing ldap output, the files *must* be prefixed with "pyldapsearch".
+# In order to provide bofhound with a folder containing ldap output, the files *must* be with .log extension.
 python3 split_output.py -i ldap_output.txt -o pyldapsearch_ldap -n 100
 
 # Provide Shadowhound with a folder containing the splitted output
 python3 bofhound.py -i ./folder -p All --parser ldapsearch
-
 ```
 
 After collecting data, use [BofHound](https://github.com/coffeegist/bofhound) to convert it into BloodHound-compatible JSON files:
 
 ```bash
-python3 bofhound.py -i ldap_output.txt -p All --parser ldapsearch
+python3 bofhound.py -i ldap_output.log -p All --parser ldapsearch
 ```
 
 For large JSON files (>100MB), consider splitting them with tools like [ShredHound](https://github.com/ustayready/ShredHound).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ShadowHound-ADM -Server dc.corp.local -OutputFilePath output.txt -LetterSplitSea
 - **`-KeepStateFile`**: Preserve state file after completion
 - **`-StateFile <path>`**: Custom state file location
 
-For more details on resumable enumeration and 3-letter splitting, see the [feature PR](https://github.com/Friends-Security/ShadowHound/pull/XX).
+For more details on resumable enumeration and 3-letter splitting, see the [feature PR](https://github.com/Friends-Security/ShadowHound/pull/4).
 
 ## Converting Data for BloodHound
 

--- a/ShadowHound-ADM.ps1
+++ b/ShadowHound-ADM.ps1
@@ -774,7 +774,7 @@ function ShadowHound-ADM {
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
                                 } catch {
-                                    Write-Output "   [-] Batch failed, retrying individually..."
+                                    Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
                                     $failedBatches += ,@($batch)
                                 }
                             }
@@ -983,7 +983,7 @@ function ShadowHound-ADM {
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
                                 } catch {
-                                    Write-Output "   [-] Batch failed, retrying individually..."
+                                    Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
                                     $failedBatches += ,@($batch)
                                 }
                             }

--- a/ShadowHound-ADM.ps1
+++ b/ShadowHound-ADM.ps1
@@ -15,7 +15,7 @@ function ShadowHound-ADM {
         [string]$SearchBase,
 
         [Parameter(Mandatory = $false, HelpMessage = 'The number of objects to include in one page for paging LDAP searches.')]
-        [int]$PageSize = 1000,
+        [int]$PageSize = 500,
 
         [Parameter(Mandatory = $false, HelpMessage = 'PSCredential object for alternate credentials.')]
         [pscredential]$Credential,
@@ -35,6 +35,19 @@ function ShadowHound-ADM {
         [Parameter(Mandatory = $false, HelpMessage = 'Enumerate certificates.')]
         [switch]$Certificates,
 
+        [Parameter(Mandatory = $false, HelpMessage = 'Path to state file for checkpoint tracking.')]
+        [string]$StateFile,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Start enumeration from a specific letter or two-letter prefix (max 2 chars).')]
+        [ValidateScript({ if ($null -ne $_ -and $_.Length -gt 2) { throw 'StartFromLetter must be maximum 2 characters.' } $true })]
+        [string]$StartFromLetter,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Disable state file functionality.')]
+        [switch]$DisableStateFile,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Keep state file after successful completion.')]
+        [switch]$KeepStateFile,
+
         [Parameter(Mandatory = $false, HelpMessage = 'Display help information.')]
         [switch]$Help
     )
@@ -45,7 +58,7 @@ function ShadowHound-ADM {
     }
 
     if ($Certificates -and ($SplitSearch -or $LetterSplitSearch -or $Recurse -or $ParsedContainers -or $SearchBase)) { 
-        Write-Error '[!] Certificate enumeration is done seprately from the rest of the enumeration.'
+        Write-Error '[!] Certificate enumeration is done separately from the rest of the enumeration.'
         return
     }
 
@@ -72,7 +85,7 @@ function ShadowHound-ADM {
 
     Print-Logo
     Write-Output '[+] Executing with the following parameters:'
-    if ($server) { Write-Output "   - Server: $Server" }
+    if ($Server) { Write-Output "   - Server: $Server" }
     Write-Output "   - OutputFilePath: $OutputFilePath"
     if ($LdapFilter) { Write-Output "   - LdapFilter: $LdapFilter" }
     if ($SearchBase) { Write-Output "   - SearchBase: $SearchBase" }
@@ -81,6 +94,8 @@ function ShadowHound-ADM {
     if ($Recurse) { Write-Output '   - Recurse enabled' }
     if ($Credential) { Write-Output "   - Credential: $($Credential.UserName)" }
     if ($ParsedContainers) { Write-Output "   - ParsedContainers: $ParsedContainers" }
+    if ($StartFromLetter) { Write-Output "   - StartFromLetter: $StartFromLetter" }
+    if ($DisableStateFile) { Write-Output '   - StateFile: disabled' } elseif ($StateFile) { Write-Output "   - StateFile: $StateFile" }
     if ($Certificates) { Write-Output '   - Enumerating certificates' }
 
 
@@ -97,6 +112,115 @@ function ShadowHound-ADM {
     if ($SearchBase) { $getAdObjectParams['SearchBase'] = $SearchBase }
     if ($Credential) { $getAdObjectParams['Credential'] = $Credential }
     if ($PageSize) { $getAdObjectParams['ResultPageSize'] = $PageSize }
+
+    # State file handling
+    $stateEnabled = $true
+    if ($DisableStateFile) { $stateEnabled = $false }
+    $statePath = $null
+    if ($stateEnabled) {
+        if ($StateFile) { $statePath = $StateFile } else { $statePath = "$OutputFilePath.state.json" }
+        $resumeChoice = $null
+        if (Test-StateFileExists -Path $statePath) {
+            $existingState = Read-StateFile -Path $statePath
+            
+            # Handle corrupted state file
+            if ($null -eq $existingState) {
+                Write-Output ''
+                Write-Output '[!] WARNING: State file exists but is corrupted or unreadable.'
+                Write-Output "[!] Path: $statePath"
+                Write-Output ''
+                while ($true) {
+                    $corruptChoice = Read-Host '[?] Delete corrupted state file and start fresh? [Y]es, [C]ancel'
+                    $corruptChoice = $corruptChoice.Trim().ToUpper()
+                    if ($corruptChoice -eq 'Y' -or $corruptChoice -eq 'YES') {
+                        Write-Output '[+] Deleting corrupted state file and starting fresh...'
+                        Remove-StateFile -Path $statePath
+                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                        break
+                    } elseif ($corruptChoice -eq 'C' -or $corruptChoice -eq 'CANCEL') {
+                        Write-Output '[-] Cancelled by user'
+                        return
+                    } else {
+                        Write-Output '[!] Invalid input. Please enter Y or C.'
+                    }
+                }
+            } elseif ($existingState['toolMethod'] -and $existingState['toolMethod'] -ne 'ShadowHound-ADM') {
+                Write-Output ''
+                Write-Output "[!] WARNING: State file was created with $($existingState['toolMethod'])."
+                Write-Output '[!] Resuming with ShadowHound-ADM is not possible.'
+                Write-Output "[!] Path: $statePath"
+                Write-Output ''
+                while ($true) {
+                    $toolChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
+                    $toolChoice = $toolChoice.Trim().ToUpper()
+                    if ($toolChoice -eq 'Y' -or $toolChoice -eq 'YES') {
+                        Write-Output '[+] Deleting state file and starting fresh...'
+                        Remove-StateFile -Path $statePath
+                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                        break
+                    } elseif ($toolChoice -eq 'C' -or $toolChoice -eq 'CANCEL') {
+                        Write-Output '[-] Cancelled by user'
+                        return
+                    } else {
+                        Write-Output '[!] Invalid input. Please enter Y or C.'
+                    }
+                }
+            } elseif ($existingState['executionMode']) {
+                # Check execution mode compatibility
+                $currentMode = 'Standard'
+                if ($SplitSearch -and $LetterSplitSearch) {
+                    $currentMode = 'SplitSearch+LetterSplitSearch'
+                } elseif ($SplitSearch) {
+                    $currentMode = 'SplitSearch'
+                } elseif ($LetterSplitSearch) {
+                    $currentMode = 'LetterSplitSearch'
+                }
+                
+                if ($existingState['executionMode'] -ne $currentMode) {
+                    Write-Output ''
+                    Write-Output "[!] WARNING: State file execution mode mismatch."
+                    Write-Output "[!] State file mode: $($existingState['executionMode'])"
+                    Write-Output "[!] Current execution mode: $currentMode"
+                    Write-Output '[!] Resuming with mismatched modes will cause data integrity issues.'
+                    Write-Output "[!] Path: $statePath"
+                    Write-Output ''
+                    while ($true) {
+                        $modeChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
+                        $modeChoice = $modeChoice.Trim().ToUpper()
+                        if ($modeChoice -eq 'Y' -or $modeChoice -eq 'YES') {
+                            Write-Output '[+] Deleting state file and starting fresh...'
+                            Remove-StateFile -Path $statePath
+                            $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                            break
+                        } elseif ($modeChoice -eq 'C' -or $modeChoice -eq 'CANCEL') {
+                            Write-Output '[-] Cancelled by user'
+                            return
+                        } else {
+                            Write-Output '[!] Invalid input. Please enter Y or C.'
+                        }
+                    }
+                } else {
+                    $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath
+                    switch ($resumeChoice) {
+                        'Y' { $stateData = $existingState }
+                        'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                        'C' { return }
+                        default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                    }
+                }
+            } else {
+                $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath
+                switch ($resumeChoice) {
+                    'Y' { $stateData = $existingState }
+                    'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                    'C' { return }
+                    default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                }
+            }
+        } else {
+            $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+        }
+    }
 
     # Open StreamWriter
     $streamWriter = New-Object System.IO.StreamWriter($OutputFilePath, $true, [System.Text.Encoding]::UTF8)
@@ -148,7 +272,7 @@ function ShadowHound-ADM {
                 LdapFilter = '(objectClass=domain)'
             }
 
-            if ($server) { $dcSearchParams['Server'] = $Server }
+            if ($Server) { $dcSearchParams['Server'] = $Server }
             if ($Credential) { $dcSearchParams['Credential'] = $Credential }
 
             Perform-ADQuery -SearchParams $dcSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
@@ -179,12 +303,20 @@ function ShadowHound-ADM {
                 $ParsedContainersList = @()
             }
 
-            # process them containers
+            $isFirstContainer = $true
             foreach ($container in $topLevelContainers) {
                 $containerDN = $container.DistinguishedName
 
+                # Skip containers from ParsedContainers file
                 if ($ParsedContainersList -contains $containerDN) {
                     Write-Output "[+] Encountered already parsed container $containerDN, skipping..."
+                    $processedContainers += $containerDN
+                    continue
+                }
+                
+                # Skip already completed containers from state file
+                if ($stateEnabled -and $stateData -and $stateData.completedContainers -contains $containerDN) {
+                    Write-Output "[+] Container $containerDN already completed, skipping..."
                     $processedContainers += $containerDN
                     continue
                 }
@@ -209,21 +341,184 @@ function ShadowHound-ADM {
                     # Split the search by first letter
                     $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
                     $OriginalFilter = $containerSearchParams['LdapFilter']
-                    foreach ($char in $charset) {
-                        Write-Output "  [*] Querying $containerDN for objects with CN starting with '$char'"
-                        $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$char**))"
+                    
+                    # Determine starting letter for this container
+                    $startIdx = 0
+                    if ($stateEnabled -and $stateData -and $stateData.currentContainer -eq $containerDN -and $stateData.completedLetters) {
+                        # Resuming this container - use completed letters from state
+                        $completedSet = @($stateData.completedLetters)
+                    } elseif ($StartFromLetter -and $isFirstContainer) {
+                        # User specified starting letter - apply only to first container
+                        $completedSet = @()
+                        for ($i = 0; $i -lt $charset.Length; $i++) {
+                            if ($charset[$i] -eq $StartFromLetter[0]) {
+                                $startIdx = $i
+                                break
+                            }
+                        }
+                    } else {
+                        $completedSet = @()
+                    }
+                    
+                    foreach ($char in $charset[$startIdx..($charset.Length-1)]) {
+                        $charStr = [string]$char
+                        
+                        # Skip if already completed
+                        if ($completedSet -contains $charStr) {
+                            Write-Output "  [+] Letter '$charStr' already completed, skipping..."
+                            continue
+                        }
+                        
+                        # Check if we have any subletters starting with this letter already completed
+                        $hasSubletters = $false
+                        foreach ($completed in $completedSet) {
+                            if ($completed.Length -eq 2 -and $completed[0] -eq $char) {
+                                $hasSubletters = $true
+                                break
+                            }
+                        }
+                        
+                        # Handle cases where we need to skip single letter and enumerate subletters:
+                        # 1. -StartFromLetter with 2-char prefix
+                        # 2. We have subletters in completedSet (resume scenario)
+                        if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
+                            $subStartIdx = 0
+                            
+                            # Determine starting subletter index
+                            if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
+                                # User specified a starting subletter
+                                for ($i = 0; $i -lt $charset.Length; $i++) {
+                                    if ($charset[$i] -eq $StartFromLetter[1]) {
+                                        $subStartIdx = $i
+                                        break
+                                    }
+                                }
+                                Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
+                            }
+                            
+                            $subCharset = $charset[$subStartIdx..($charset.Length-1)]
+                            foreach ($subChar in $subCharset) {
+                                $doubleChar = "$charStr$subChar"
+                                
+                                $isRetry = $false
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                    $isRetry = $true
+                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
+                                }
+                                
+                                if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                                    Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                                    continue
+                                }
+                                
+                                try {
+                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
+                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
+                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    
+                                    # Checkpoint after successful subletter query
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                            $stateData.completedLetters += $doubleChar
+                                        }
+                                        
+                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($containerDN)
+                                            }
+                                        }
+                                        
+                                        $stateData.currentContainer = $containerDN
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                } catch {
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
+                                    
+                                    # Track failed letter for this container
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$containerDN]) {
+                                            $stateData.failedLetters[$containerDN] = @()
+                                        }
+                                        if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] += $doubleChar
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                    continue
+                                }
+                            }
+                            continue
+                        }
+                        
+                        Write-Output "  [*] Querying $containerDN for objects with CN starting with '$charStr'"
+                        $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
 
                         try {
                             Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
+                            # Checkpoint after successful query
+                            if ($stateEnabled -and $stateData) {
+                                $stateData.completedLetters += $charStr
+                                $stateData.currentContainer = $containerDN
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
                         } catch {
-                            Write-Output "   [!!] Error processing CN=$char* for container '$containerDN': $_`nTrying to split each letter again..."
-                            foreach ($subChar in $charset) {
+                            Write-Output "   [!!] Error processing CN=$charStr* for container '$containerDN': $_`nTrying to split each letter again..."
+                            $subCharset = $charset
+                            foreach ($subChar in $subCharset) {
+                                $doubleChar = "$charStr$subChar"
+                                
+                                $isRetry = $false
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                    $isRetry = $true
+                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
+                                }
+                                
+                                if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                                    Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                                    continue
+                                }
+                                
                                 try {
-                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$char$subChar'"
-                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$char$subChar**))"
+                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
+                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
                                     Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    
+                                    # Checkpoint after successful subletter query
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                            $stateData.completedLetters += $doubleChar
+                                        }
+                                        
+                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($containerDN)
+                                            }
+                                        }
+                                        
+                                        $stateData.currentContainer = $containerDN
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
                                 } catch {
-                                    Write-Output "   [-] Failed to process (CN=$char$subChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
+                                    
+                                    # Track failed letter for this container
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$containerDN]) {
+                                            $stateData.failedLetters[$containerDN] = @()
+                                        }
+                                        if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] += $doubleChar
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
                                     continue
                                 }
                             }
@@ -231,6 +526,14 @@ function ShadowHound-ADM {
                     }
 
                     $processedContainers += $containerDN
+                    $isFirstContainer = $false
+                    
+                    if ($stateEnabled -and $stateData) {
+                        $stateData.completedContainers += $containerDN
+                        $stateData.completedLetters = @()
+                        $stateData.currentContainer = $null
+                        Write-StateFile -State $stateData -Path $statePath
+                    }
                 }
             }
 
@@ -244,30 +547,518 @@ function ShadowHound-ADM {
                 Write-Output "`n[-] Failed to process containers:"
                 $unprocessedContainers | ForEach-Object { Write-Output "    - $_" }
             }
+            
+            # Report failed letters if any
+            if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                Write-Output ''
+                Write-Output "[!] WARNING: Failed to enumerate letters for the following containers:"
+                Write-Output ''
+                foreach ($container in $stateData.failedLetters.Keys) {
+                    $letters = $stateData.failedLetters[$container] -join ', '
+                    Write-Output "  Container: $container"
+                    Write-Output "  Failed letters: $letters"
+                    Write-Output ''
+                }
+                Write-Output "[!] Partial or no data written for these letters before failure."
+                Write-Output "[!] State file preserved. Resuming will retry failed letters."
+                Write-Output ''
+                Write-Output "[!] If failures persist, try these manual enumeration strategies:"
+                Write-Output ''
+                Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
+                Write-Output "    # Targets specific year instead of broad '20*' pattern"
+                Write-Output ''
+                Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<failed-container-DN>' -OutputFilePath <output>"
+                Write-Output "    # Enumerate one level deeper to reduce object count per query"
+                Write-Output ''
+                Write-Output "  Option 3 - Combine filters and letter splitting:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
+                Write-Output "    # Narrow the pattern and still use letter splitting for safety"
+                Write-Output ''
+            }
         } elseif ($LetterSplitSearch -eq $true -and $SplitSearch -eq $false) {
             $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
             $OriginalFilter = $getAdObjectParams['LdapFilter']
-            foreach ($char in $charset) {
-                Write-Output "  [*] Querying for objects with CN starting with '$char'"
-                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$char**))"
+            $globalKey = 'global'
+            
+            $startIdx = 0
+            $completedSet = @()
+            if ($stateEnabled -and $stateData -and $stateData.completedLetters) {
+                $completedSet = @($stateData.completedLetters)
+            } elseif ($StartFromLetter) {
+                for ($i = 0; $i -lt $charset.Length; $i++) {
+                    if ($charset[$i] -eq $StartFromLetter[0]) {
+                        $startIdx = $i
+                        break
+                    }
+                }
+            }
+            
+            foreach ($char in $charset[$startIdx..($charset.Length-1)]) {
+                $charStr = [string]$char
+                
+                # Skip if already completed
+                if ($completedSet -contains $charStr) {
+                    Write-Output "  [+] Letter '$charStr' already completed, skipping..."
+                    continue
+                }
+                
+                # Check if we have any subletters starting with this letter already completed
+                $hasSubletters = $false
+                foreach ($completed in $completedSet) {
+                    if ($completed.Length -eq 2 -and $completed[0] -eq $char) {
+                        $hasSubletters = $true
+                        break
+                    }
+                }
+                
+                # Handle cases where we need to skip single letter and enumerate subletters:
+                # 1. -StartFromLetter with 2-char prefix
+                # 2. We have subletters in completedSet (resume scenario)
+                if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
+                    $subStartIdx = 0
+                    
+                    # Determine starting subletter index
+                    if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
+                        # User specified a starting subletter
+                        for ($i = 0; $i -lt $charset.Length; $i++) {
+                            if ($charset[$i] -eq $StartFromLetter[1]) {
+                                $subStartIdx = $i
+                                break
+                            }
+                        }
+                        Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
+                    }
+                    
+                    $subCharset = $charset[$subStartIdx..($charset.Length-1)]
+                    foreach ($subChar in $subCharset) {
+                        $doubleChar = "$charStr$subChar"
+                        $isRetry = $false
+                        
+                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                            $isRetry = $true
+                            Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
+                        }
+                        
+                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                            continue
+                        }
+                        
+                        $hasTripleLetters = $false
+                        foreach ($completed in $completedSet) {
+                            if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
+                                $hasTripleLetters = $true
+                                break
+                            }
+                        }
+                        
+                        if ($hasTripleLetters) {
+                            Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
+                            
+                            # Iterate all 3-letter combinations for this 2-letter prefix
+                            foreach ($tripleChar in $charset) {
+                                $triplePrefix = "$doubleChar$tripleChar"
+                                
+                                # Check if already completed
+                                if ($completedSet -contains $triplePrefix) {
+                                    Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
+                                    continue
+                                }
+                                
+                                # Check if in failedLetters and needs retry
+                                $isFailedRetry = $false
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                    $isFailedRetry = $true
+                                    Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
+                                }
+                                
+                                if ($isFailedRetry) {
+                                    try {
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        
+                                        # Success - add to completed, remove from failed
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($globalKey)
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        Write-Output "      [+] Successfully retried '$triplePrefix'"
+                                    } catch {
+                                        Write-Output "      [-] Retry failed for '$triplePrefix': $_"
+                                        # Keep in failedLetters for future retry
+                                    }
+                                }
+                            }
+                            
+                            continue
+                        }
+                        
+                        try {
+                            Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
+                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
+                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
+                            # Checkpoint after successful subletter query
+                            if ($stateEnabled -and $stateData) {
+                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                    $stateData.completedLetters += $doubleChar
+                                }
+                                
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                }
+                                
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                        } catch {
+                            Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
+                            Write-Output '       Trying to split to 3-letter prefixes...'
+                            
+                            $batchSize = 4
+                            $tripleSuccess = $false
+                            $failedBatches = @()
+                            
+                            for ($batchIdx = 0; $batchIdx -lt $charset.Length; $batchIdx += $batchSize) {
+                                $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charset.Length - 1)
+                                $batch = $charset[$batchIdx..$batchEnd]
+                                
+                                $orFilters = @()
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    $orFilters += "(cn=$triplePrefix*)"
+                                }
+                                
+                                $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+                                
+                                try {
+                                    Write-Output "  [*] Querying batch: $batchNames"
+                                    $getAdObjectParams['LdapFilter'] = $batchFilter
+                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    $tripleSuccess = $true
+                                    
+                                    if ($stateEnabled -and $stateData) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                } catch {
+                                    Write-Output "   [-] Batch failed, retrying individually..."
+                                    $failedBatches += ,@($batch)
+                                }
+                            }
+                            
+                            foreach ($batch in $failedBatches) {
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    
+                                    try {
+                                        Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        $tripleSuccess = $true
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    } catch {
+                                        Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not $stateData.failedLetters[$globalKey]) {
+                                                $stateData.failedLetters[$globalKey] = @()
+                                            }
+                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] += $triplePrefix
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        continue
+                                    }
+                                }
+                            }
+                            
+                            if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                    Write-StateFile -State $stateData -Path $statePath
+                                }
+                            } elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
+                                if (-not $stateData.failedLetters[$globalKey]) {
+                                    $stateData.failedLetters[$globalKey] = @()
+                                }
+                                if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] += $doubleChar
+                                }
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                            continue
+                        }
+                    }
+                    continue
+                }
+                
+                Write-Output "  [*] Querying for objects with CN starting with '$charStr'"
+                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
 
                 try {
                     Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                    
+                    # Checkpoint after successful query
+                    if ($stateEnabled -and $stateData) {
+                        $stateData.completedLetters += $charStr
+                        $stateData.objectCount = $count.Value
+                        Write-StateFile -State $stateData -Path $statePath
+                    }
                 } catch {
-                    Write-Output "   [!!] Error processing character '$char*': $_"
+                    Write-Output "   [!!] Error processing character '$charStr*': $_"
                     Write-Output '        Trying to split each letter again...'
-                    foreach ($subChar in $charset) {
+                    $subCharset = $charset
+                    foreach ($subChar in $subCharset) {
+                        $doubleChar = "$charStr$subChar"
+                        $isRetry = $false
+                        
+                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                            $isRetry = $true
+                            Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
+                        }
+                        
+                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                            continue
+                        }
+                        
+                        $hasTripleLetters = $false
+                        foreach ($completed in $completedSet) {
+                            if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
+                                $hasTripleLetters = $true
+                                break
+                            }
+                        }
+                        
+                        if ($hasTripleLetters) {
+                            Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
+                            
+                            # Iterate all 3-letter combinations for this 2-letter prefix
+                            foreach ($tripleChar in $charset) {
+                                $triplePrefix = "$doubleChar$tripleChar"
+                                
+                                # Check if already completed
+                                if ($completedSet -contains $triplePrefix) {
+                                    Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
+                                    continue
+                                }
+                                
+                                # Check if in failedLetters and needs retry
+                                $isFailedRetry = $false
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                    $isFailedRetry = $true
+                                    Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
+                                }
+                                
+                                if ($isFailedRetry) {
+                                    try {
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        
+                                        # Success - add to completed, remove from failed
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($globalKey)
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        Write-Output "      [+] Successfully retried '$triplePrefix'"
+                                    } catch {
+                                        Write-Output "      [-] Retry failed for '$triplePrefix': $_"
+                                        # Keep in failedLetters for future retry
+                                    }
+                                }
+                            }
+                            
+                            continue
+                        }
+                        
                         try {
-                            Write-Output "  [*] Querying for objects with CN starting with '$char$subChar'"
-                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$char$subChar**))"
+                            Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
+                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
                             Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
+                            # Checkpoint after successful subletter query
+                            if ($stateEnabled -and $stateData) {
+                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                    $stateData.completedLetters += $doubleChar
+                                }
+                                
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                }
+                                
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
                         } catch {
-                            Write-Output "   [-] Failed to process (CN=$char$subChar*): $_"
-                            Write-Output '       Moving to the next sub letter...'
+                            Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
+                            Write-Output '       Trying to split to 3-letter prefixes...'
+                            
+                            $batchSize = 4
+                            $tripleSuccess = $false
+                            $failedBatches = @()
+                            
+                            for ($batchIdx = 0; $batchIdx -lt $charset.Length; $batchIdx += $batchSize) {
+                                $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charset.Length - 1)
+                                $batch = $charset[$batchIdx..$batchEnd]
+                                
+                                $orFilters = @()
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    $orFilters += "(cn=$triplePrefix*)"
+                                }
+                                
+                                $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+                                
+                                try {
+                                    Write-Output "  [*] Querying batch: $batchNames"
+                                    $getAdObjectParams['LdapFilter'] = $batchFilter
+                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    $tripleSuccess = $true
+                                    
+                                    if ($stateEnabled -and $stateData) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                } catch {
+                                    Write-Output "   [-] Batch failed, retrying individually..."
+                                    $failedBatches += ,@($batch)
+                                }
+                            }
+                            
+                            foreach ($batch in $failedBatches) {
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    
+                                    try {
+                                        Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        $tripleSuccess = $true
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    } catch {
+                                        Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not $stateData.failedLetters[$globalKey]) {
+                                                $stateData.failedLetters[$globalKey] = @()
+                                            }
+                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] += $triplePrefix
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        continue
+                                    }
+                                }
+                            }
+                            
+                            if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                    Write-StateFile -State $stateData -Path $statePath
+                                }
+                            } elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
+                                if (-not $stateData.failedLetters[$globalKey]) {
+                                    $stateData.failedLetters[$globalKey] = @()
+                                }
+                                if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] += $doubleChar
+                                }
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
                             continue
                         }
                     }
                 }
+            }
+            
+            if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                Write-Output ''
+                Write-Output "[!] WARNING: Failed to enumerate the following letters:"
+                if ($stateData.failedLetters[$globalKey]) {
+                    $letters = $stateData.failedLetters[$globalKey] -join ', '
+                    Write-Output "  Failed letters: $letters"
+                }
+                Write-Output ''
+                Write-Output "[!] Partial or no data written for these letters before failure."
+                Write-Output "[!] State file preserved. Resuming will retry failed letters."
+                Write-Output ''
+                Write-Output "[!] If failures persist, try these manual enumeration strategies:"
+                Write-Output ''
+                Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
+                Write-Output "    # Targets specific year instead of broad '20*' pattern"
+                Write-Output ''
+                Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<search-base>' -OutputFilePath <output>"
+                Write-Output "    # Enumerate one level deeper to reduce object count per query"
+                Write-Output ''
+                Write-Output "  Option 3 - Combine filters and letter splitting:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
+                Write-Output "    # Narrow the pattern and still use letter splitting for safety"
+                Write-Output ''
             }
         }
 
@@ -277,6 +1068,19 @@ function ShadowHound-ADM {
     } finally {
         $streamWriter.Flush()
         $streamWriter.Close()
+    }
+
+    # State cleanup on completion
+    if ($stateEnabled -and $statePath -and -not $KeepStateFile) {
+        # Only remove state file if no failures occurred
+        if ($stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+            Write-Output '[*] State file preserved due to failed letters:' $statePath
+        } else {
+            Write-Output '[*] Enumeration complete, removing state file...'
+            Remove-StateFile -Path $statePath
+        }
+    } elseif ($stateEnabled -and $KeepStateFile) {
+        Write-Output '[*] State file preserved:' $statePath
     }
 
     Write-Output "Objects have been processed and written to $OutputFilePath"
@@ -332,7 +1136,7 @@ function Print-Help {
 ShadowHound-ADM Help
 
 SYNTAX:
-    ShadowHound-ADM [-Server <string>] -OutputFilePath <string> [-LdapFilter <string>] [-SearchBase <string>] [-PageSize <int>] [-Credential <pscredential>] [-SplitSearch] [-LetterSplitSearch] [-ParsedContainers <string>] [-Recurse] [-Help]
+    ShadowHound-ADM [-Server <string>] -OutputFilePath <string> [-LdapFilter <string>] [-SearchBase <string>] [-PageSize <int>] [-Credential <pscredential>] [-SplitSearch] [-LetterSplitSearch] [-ParsedContainers <string>] [-Recurse] [-Certificates] [-StateFile <string>] [-StartFromLetter <string>] [-DisableStateFile] [-KeepStateFile] [-Help]
 
 PARAMETERS:
     -Help
@@ -373,6 +1177,23 @@ PARAMETERS:
     -Recurse [Optional]
         Recursively process containers that fail.
 
+    -StateFile <string> [Optional]
+        Path to state file for checkpoint tracking.
+        If not specified, defaults to <OutputFilePath>.state.json.
+
+    -StartFromLetter <string> [Optional]
+        Start enumeration from a specific letter (max 2 chars).
+        Examples: "d", "ah", "@"
+        Skips all letters before the specified starting point.
+
+    -DisableStateFile [Optional]
+        Disable state file functionality entirely.
+        No checkpoints created, no resume capability.
+
+    -KeepStateFile [Optional]
+        Preserve state file after successful completion.
+        By default, state file is automatically deleted on completion.
+
 EXAMPLES:
     # Example 1: Basic usage with required parameter
     ShadowHound-ADM -OutputFilePath "C:\Results\output.txt"
@@ -389,6 +1210,15 @@ EXAMPLES:
 
     # Example 5: Enumerate certificates
     ShadowHound-ADM -OutputFilePath "C:\Results\output.txt" -Certificates
+
+    # Example 6: Resume after interruption (auto-detects state file)
+    ShadowHound-ADM -OutputFilePath "C:\Results\output.txt" -LetterSplitSearch
+
+    # Example 7: Start from specific letter
+    ShadowHound-ADM -OutputFilePath "C:\Results\output.txt" -LetterSplitSearch -StartFromLetter "m"
+
+    # Example 8: Disable state file for zero artifacts
+    ShadowHound-ADM -OutputFilePath "C:\Results\output.txt" -LetterSplitSearch -DisableStateFile
 '
     Write-Host $helpMessage
     return
@@ -642,15 +1472,17 @@ function Perform-ADQuery {
         [int]$PrintingThreshold = 1000
     )
 
-    # Process the objects
+    $SearchParams['ResultSetSize'] = 100000
+    
     Get-ADObject @SearchParams | ForEach-Object {
         Process-AdObject -AdObject $_ -StreamWriter $StreamWriter
         $Count.Value++
         if ($Count.Value % $PrintingThreshold -eq 0) {
             Write-Output "      [**] Queried $($Count.Value) objects so far..."
-            $StreamWriter.Flush()
         }
     }
+    
+    $StreamWriter.Flush()
 }
 
 function Get-TopLevelContainers {
@@ -668,5 +1500,231 @@ function Get-TopLevelContainers {
     } catch {
         Write-Error "Failed to retrieve top-level containers: $_"
         return $null
+    }
+}
+
+function Initialize-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Output,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Server,
+
+        [Parameter(Mandatory = $false)]
+        [string]$LdapFilter,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SearchBase,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$SplitSearch = $false,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$LetterSplitSearch = $false
+    )
+
+    # Determine execution mode
+    $mode = 'Standard'
+    if ($SplitSearch -and $LetterSplitSearch) {
+        $mode = 'SplitSearch+LetterSplitSearch'
+    } elseif ($SplitSearch) {
+        $mode = 'SplitSearch'
+    } elseif ($LetterSplitSearch) {
+        $mode = 'LetterSplitSearch'
+    }
+
+    $state = @{
+        version = '1.0'
+        toolMethod = 'ShadowHound-ADM'
+        timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        outputFile = $Output
+        executionMode = $mode
+        ldapFilter = if ($LdapFilter) { $LdapFilter } else { '(objectGuid=*)' }
+        completedContainers = @()
+        completedLetters = @()
+        failedLetters = @{}
+        objectCount = 0
+    }
+
+    if ($Server) { $state.server = $Server }
+    if ($SearchBase) { $state.searchBase = $SearchBase }
+
+    return $state
+}
+
+function Test-StateFileExists {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return (Test-Path -Path $Path -PathType Leaf)
+}
+
+function Read-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    try {
+        $json = Get-Content -Path $Path -Raw -ErrorAction Stop
+        $psobject = $json | ConvertFrom-Json -ErrorAction Stop
+        
+        $state = @{}
+        $psobject.PSObject.Properties | ForEach-Object {
+            $name = $_.Name
+            $value = $_.Value
+            
+            if ($value -is [PSCustomObject]) {
+                $nested = @{}
+                $value.PSObject.Properties | ForEach-Object {
+                    $nested[$_.Name] = $_.Value
+                }
+                $state[$name] = $nested
+            } else {
+                $state[$name] = $value
+            }
+        }
+        
+        return $state
+    } catch {
+        return $null
+    }
+}
+
+function Write-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [hashtable]$State,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    try {
+        $State.timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $json = $State | ConvertTo-Json -Depth 10
+        
+        try {
+            $json = [regex]::Replace($json, '(?ms)\[(\s*"[^"]*"\s*(?:,\s*"[^"]*"\s*)*)\]', {
+                param($match)
+                $content = $match.Groups[1].Value
+                $compacted = $content -replace '\s+', ''
+                "[$compacted]"
+            })
+        } catch {
+            # Regex failed, use formatted JSON as-is
+        }
+        
+        $json | Set-Content -Path $Path -Force -ErrorAction Stop
+    } catch {
+        Write-Error "[-] Failed to write state file: $_"
+    }
+}
+
+function Remove-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (Test-Path -Path $Path) {
+        try {
+            Remove-Item -Path $Path -Force -ErrorAction Stop
+        } catch {
+            Write-Error "[-] Failed to remove state file: $_"
+        }
+    }
+}
+
+function Show-StatePrompt {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        $State,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    [Console]::WriteLine('')
+    [Console]::WriteLine('[*] Found existing state file: ' + $Path)
+    [Console]::WriteLine('[*] Last checkpoint:')
+    
+    $containers = $State['completedContainers']
+    if ($containers -and $containers.Count -gt 0) {
+        [Console]::WriteLine("    - Completed containers: $($containers.Count)")
+    }
+    
+    $currentContainer = $State['currentContainer']
+    if ($currentContainer) {
+        [Console]::WriteLine("    - Current container: $currentContainer")
+    }
+    
+    $letters = $State['completedLetters']
+    if ($letters -and $letters.Count -gt 0) {
+        $letterList = $letters -join ', '
+        if ($currentContainer) {
+            [Console]::WriteLine("    - Completed letters (in current container): $letterList")
+        } else {
+            [Console]::WriteLine("    - Completed letters: $letterList")
+        }
+    } elseif ($currentContainer) {
+        [Console]::WriteLine('    - Completed letters (in current container): (none yet)')
+    } else {
+        [Console]::WriteLine('    - Completed letters: (none yet)')
+    }
+    
+    $objCount = $State['objectCount']
+    if ($objCount -and $objCount -gt 0) {
+        [Console]::WriteLine("    - Objects enumerated: $objCount")
+    }
+    
+    $failedLetters = $State['failedLetters']
+    if ($failedLetters -and $failedLetters.Count -gt 0) {
+        [Console]::WriteLine('')
+        [Console]::WriteLine('[!] Failed letters detected (will be retried on resume):')
+        foreach ($container in $failedLetters.Keys) {
+            $letters = $failedLetters[$container] -join ', '
+            [Console]::WriteLine("    Container: $container")
+            [Console]::WriteLine("    Letters: $letters")
+        }
+    }
+    
+    $timestamp = $State['timestamp']
+    if ($timestamp) {
+        [Console]::WriteLine("    - Timestamp: $timestamp")
+    }
+    
+    [Console]::WriteLine('')
+    [Console]::WriteLine('[!] Note: Resuming will append to existing output file')
+    [Console]::WriteLine('')
+
+    while ($true) {
+        $choice = Read-Host '[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel'
+        $choice = $choice.Trim().ToUpper()
+        
+        if ($choice -eq 'Y' -or $choice -eq 'YES') {
+            [Console]::WriteLine('[+] Resuming from checkpoint...')
+            return 'Y'
+        } elseif ($choice -eq 'N' -or $choice -eq 'NO') {
+            [Console]::WriteLine('[+] Starting fresh enumeration...')
+            return 'N'
+        } elseif ($choice -eq 'C' -or $choice -eq 'CANCEL') {
+            [Console]::WriteLine('[-] Cancelled by user')
+            return 'C'
+        } else {
+            [Console]::WriteLine('[!] Invalid input. Please enter Y, N, or C.')
+        }
     }
 }

--- a/ShadowHound-ADM.ps1
+++ b/ShadowHound-ADM.ps1
@@ -49,10 +49,7 @@ function ShadowHound-ADM {
         [switch]$KeepStateFile,
 
         [Parameter(Mandatory = $false, HelpMessage = 'Display help information.')]
-        [switch]$Help,
-
-        [Parameter(Mandatory = $false, HelpMessage = 'Disable interactive prompts for automation and C2.')]
-        [switch]$NonInteractive
+        [switch]$Help
     )
 
     if ($Help) {
@@ -76,6 +73,11 @@ function ShadowHound-ADM {
         return
     }
 
+    if ($StartFromLetter -and -not $LetterSplitSearch) {
+        Write-Error '[!] -StartFromLetter requires -LetterSplitSearch to be enabled.'
+        return
+    }
+
     if ($ParsedContainers -and -not $SplitSearch) {
         Write-Error '[!] Cannot parse containers if -SplitSearch is not provided.'
         return
@@ -91,10 +93,6 @@ function ShadowHound-ADM {
         return
     }
 
-    if ($StartFromLetter -and -not $LetterSplitSearch) {
-        Write-Error '[!] -StartFromLetter requires -LetterSplitSearch to be enabled.'
-        return
-    }
 
     Print-Logo
     Write-Output '[+] Executing with the following parameters:'
@@ -110,6 +108,8 @@ function ShadowHound-ADM {
     if ($StartFromLetter) { Write-Output "   - StartFromLetter: $StartFromLetter" }
     if ($DisableStateFile) { Write-Output '   - StateFile: disabled' } elseif ($StateFile) { Write-Output "   - StateFile: $StateFile" }
     if ($Certificates) { Write-Output '   - Enumerating certificates' }
+
+    
 
 
     $count = [ref]0
@@ -142,22 +142,79 @@ function ShadowHound-ADM {
                 Write-Output '[!] WARNING: State file exists but is corrupted or unreadable.'
                 Write-Output "[!] Path: $statePath"
                 Write-Output ''
-                if ($NonInteractive) {
-                    Write-Output '[*] Non-interactive mode: Deleting corrupted state file and starting fresh...'
-                    Remove-StateFile -Path $statePath
-                    $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                while ($true) {
+                    $corruptChoice = Read-Host '[?] Delete corrupted state file and start fresh? [Y]es, [C]ancel'
+                    $corruptChoice = $corruptChoice.Trim().ToUpper()
+                    if ($corruptChoice -eq 'Y' -or $corruptChoice -eq 'YES') {
+                        Write-Output '[+] Deleting corrupted state file and starting fresh...'
+                        Remove-StateFile -Path $statePath
+                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                        break
+                    }
+                    elseif ($corruptChoice -eq 'C' -or $corruptChoice -eq 'CANCEL') {
+                        Write-Output '[-] Cancelled by user'
+                        return
+                    }
+                    else {
+                        Write-Output '[!] Invalid input. Please enter Y or C.'
+                    }
                 }
-                else {
+            }
+            elseif ($existingState['toolMethod'] -and $existingState['toolMethod'] -ne 'ShadowHound-ADM') {
+                Write-Output ''
+                Write-Output "[!] WARNING: State file was created with $($existingState['toolMethod'])."
+                Write-Output '[!] Resuming with ShadowHound-ADM is not possible.'
+                Write-Output "[!] Path: $statePath"
+                Write-Output ''
+                while ($true) {
+                    $toolChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
+                    $toolChoice = $toolChoice.Trim().ToUpper()
+                    if ($toolChoice -eq 'Y' -or $toolChoice -eq 'YES') {
+                        Write-Output '[+] Deleting state file and starting fresh...'
+                        Remove-StateFile -Path $statePath
+                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                        break
+                    }
+                    elseif ($toolChoice -eq 'C' -or $toolChoice -eq 'CANCEL') {
+                        Write-Output '[-] Cancelled by user'
+                        return
+                    }
+                    else {
+                        Write-Output '[!] Invalid input. Please enter Y or C.'
+                    }
+                }
+            }
+            elseif ($existingState['executionMode']) {
+                # Check execution mode compatibility
+                $currentMode = 'Standard'
+                if ($SplitSearch -and $LetterSplitSearch) {
+                    $currentMode = 'SplitSearch+LetterSplitSearch'
+                }
+                elseif ($SplitSearch) {
+                    $currentMode = 'SplitSearch'
+                }
+                elseif ($LetterSplitSearch) {
+                    $currentMode = 'LetterSplitSearch'
+                }
+                
+                if ($existingState['executionMode'] -ne $currentMode) {
+                    Write-Output ''
+                    Write-Output "[!] WARNING: State file execution mode mismatch."
+                    Write-Output "[!] State file mode: $($existingState['executionMode'])"
+                    Write-Output "[!] Current execution mode: $currentMode"
+                    Write-Output '[!] Resuming with mismatched modes will cause data integrity issues.'
+                    Write-Output "[!] Path: $statePath"
+                    Write-Output ''
                     while ($true) {
-                        $corruptChoice = Read-Host '[?] Delete corrupted state file and start fresh? [Y]es, [C]ancel'
-                        $corruptChoice = $corruptChoice.Trim().ToUpper()
-                        if ($corruptChoice -eq 'Y' -or $corruptChoice -eq 'YES') {
-                            Write-Output '[+] Deleting corrupted state file and starting fresh...'
+                        $modeChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
+                        $modeChoice = $modeChoice.Trim().ToUpper()
+                        if ($modeChoice -eq 'Y' -or $modeChoice -eq 'YES') {
+                            Write-Output '[+] Deleting state file and starting fresh...'
                             Remove-StateFile -Path $statePath
                             $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
                             break
                         }
-                        elseif ($corruptChoice -eq 'C' -or $corruptChoice -eq 'CANCEL') {
+                        elseif ($modeChoice -eq 'C' -or $modeChoice -eq 'CANCEL') {
                             Write-Output '[-] Cancelled by user'
                             return
                         }
@@ -166,497 +223,175 @@ function ShadowHound-ADM {
                         }
                     }
                 }
-                elseif ($existingState['toolMethod'] -and $existingState['toolMethod'] -ne 'ShadowHound-ADM') {
-                    Write-Output ''
-                    Write-Output "[!] WARNING: State file was created with $($existingState['toolMethod'])."
-                    Write-Output '[!] Resuming with ShadowHound-ADM is not possible.'
-                    Write-Output "[!] Path: $statePath"
-                    Write-Output ''
-                    if ($NonInteractive) {
-                        Write-Output '[*] Non-interactive mode: Deleting state file and starting fresh...'
-                        Remove-StateFile -Path $statePath
-                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-                    }
-                    else {
-                        while ($true) {
-                            $toolChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
-                            $toolChoice = $toolChoice.Trim().ToUpper()
-                            if ($toolChoice -eq 'Y' -or $toolChoice -eq 'YES') {
-                                Write-Output '[+] Deleting state file and starting fresh...'
-                                Remove-StateFile -Path $statePath
-                                $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-                                break
-                            }
-                            elseif ($toolChoice -eq 'C' -or $toolChoice -eq 'CANCEL') {
-                                Write-Output '[-] Cancelled by user'
-                                return
-                            }
-                            else {
-                                Write-Output '[!] Invalid input. Please enter Y or C.'
-                            }
-                        }
-                    }
-                    elseif ($existingState['executionMode']) {
-                        # Check execution mode compatibility
-                        $currentMode = 'Standard'
-                        if ($SplitSearch -and $LetterSplitSearch) {
-                            $currentMode = 'SplitSearch+LetterSplitSearch'
-                        }
-                        elseif ($SplitSearch) {
-                            $currentMode = 'SplitSearch'
-                        }
-                        elseif ($LetterSplitSearch) {
-                            $currentMode = 'LetterSplitSearch'
-                        }
-                
-                        if ($existingState['executionMode'] -ne $currentMode) {
-                            Write-Output ''
-                            Write-Output "[!] WARNING: State file execution mode mismatch."
-                            Write-Output "[!] State file mode: $($existingState['executionMode'])"
-                            Write-Output "[!] Current execution mode: $currentMode"
-                            Write-Output '[!] Resuming with mismatched modes will cause data integrity issues.'
-                            Write-Output "[!] Path: $statePath"
-                            Write-Output ''
-                            if ($NonInteractive) {
-                                Write-Output '[*] Non-interactive mode: Deleting state file and starting fresh...'
-                                Remove-StateFile -Path $statePath
-                                $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-                            }
-                        }
-                        else {
-                            while ($true) {
-                                $modeChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
-                                $modeChoice = $modeChoice.Trim().ToUpper()
-                                if ($modeChoice -eq 'Y' -or $modeChoice -eq 'YES') {
-                                    Write-Output '[+] Deleting state file and starting fresh...'
-                                    Remove-StateFile -Path $statePath
-                                    $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-                                    break
-                                }
-                                elseif ($modeChoice -eq 'C' -or $modeChoice -eq 'CANCEL') {
-                                    Write-Output '[-] Cancelled by user'
-                                    return
-                                }
-                                else {
-                                    Write-Output '[!] Invalid input. Please enter Y or C.'
-                                }
-                            }
-                        }
-                        else {
-                            $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath -NonInteractive:$NonInteractive
-                            switch ($resumeChoice) {
-                                'Y' { $stateData = $existingState }
-                                'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                                'C' { return }
-                                default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                            }
-                        }
-                    }
-                    else {
-                        $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath -NonInteractive:$NonInteractive
-                        switch ($resumeChoice) {
-                            'Y' { $stateData = $existingState }
-                            'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                            'C' { return }
-                            default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                        }
-                    }
-                }
                 else {
-                    $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                    $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath
+                    switch ($resumeChoice) {
+                        'Y' { $stateData = $existingState }
+                        'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                        'C' { return }
+                        default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                    }
                 }
             }
-
-            # Open StreamWriter
-            $streamWriter = New-Object System.IO.StreamWriter($OutputFilePath, $true, [System.Text.Encoding]::UTF8)
-            try {
-                $streamWriter.WriteLine('--------------------')
-                if ($Certificates) {
-
-                    Write-Output '[*] Getting Configuration Naming Context...'
-                    $configEnumParams = @{}
-                    if ($Server) { $configEnumParams['Server'] = $Server }
-                    if ($Credential) { $configEnumParams['Credential'] = $Credential }
-                    $configContext = (Get-ADRootDSE @configEnumParams).ConfigurationNamingContext
-                    if ($null -eq $configContext) {
-                        Write-Error '[-] Failed to retrieve ConfigurationNamingContext.'
-                        return
-                    }
-
-                    Write-Output "[*] Enumerating PKI objects under $configContext..."
-                    $getAdObjectParams['SearchBase'] = $configContext
-
-                    $getAdObjectParams['LdapFilter'] = '(objectClass=pKIEnrollmentService)'
-                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-                    $getAdObjectParams['LdapFilter'] = '(objectClass=pKICertificateTemplate)'
-                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-                    $getAdObjectParams['LdapFilter'] = '(objectClass=certificationAuthority)'
-                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-                    $getAdObjectParams['LdapFilter'] = '(objectclass=msPKI-Enterprise-Oid)'
-                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
+            else {
+                $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath
+                switch ($resumeChoice) {
+                    'Y' { $stateData = $existingState }
+                    'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                    'C' { return }
+                    default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
                 }
-                elseif ($SplitSearch -eq $false -and $LetterSplitSearch -eq $false) {
+            }
+        }
+        else {
+            $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+        }
+    }
 
-                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+    # Open StreamWriter
+    $streamWriter = New-Object System.IO.StreamWriter($OutputFilePath, $true, [System.Text.Encoding]::UTF8)
+    try {
+        $streamWriter.WriteLine('--------------------')
+        if ($Certificates) {
 
-                }
-                elseif ($SplitSearch -eq $true) {
-                    # Get top-level containers
-                    Write-Output "[*] Discovering top level containers for $Server..."
-                    $topLevelContainers = Get-TopLevelContainers -Params $getAdObjectParams
-                    if ($null -eq $topLevelContainers) {
-                        Write-Error '[-] Something went wrong, no top-level containers found.'
-                        return
-                    }
+            Write-Output '[*] Getting Configuration Naming Context...'
+            $configEnumParams = @{}
+            if ($Server) { $configEnumParams['Server'] = $Server }
+            if ($Credential) { $configEnumParams['Credential'] = $Credential }
+            $configContext = (Get-ADRootDSE @configEnumParams).ConfigurationNamingContext
+            if ($null -eq $configContext) {
+                Write-Error '[-] Failed to retrieve ConfigurationNamingContext.'
+                return
+            }
 
-                    # We also need to query specifically the domain object
-                    $dcSearchParams = @{
-                        Properties = '*'
-                        LdapFilter = '(objectClass=domain)'
-                    }
+            Write-Output "[*] Enumerating PKI objects under $configContext..."
+            $getAdObjectParams['SearchBase'] = $configContext
 
-                    if ($Server) { $dcSearchParams['Server'] = $Server }
-                    if ($Credential) { $dcSearchParams['Credential'] = $Credential }
+            $getAdObjectParams['LdapFilter'] = '(objectClass=pKIEnrollmentService)'
+            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
 
-                    Perform-ADQuery -SearchParams $dcSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+            $getAdObjectParams['LdapFilter'] = '(objectClass=pKICertificateTemplate)'
+            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+            $getAdObjectParams['LdapFilter'] = '(objectClass=certificationAuthority)'
+            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+            $getAdObjectParams['LdapFilter'] = '(objectclass=msPKI-Enterprise-Oid)'
+            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+        }
+        elseif ($SplitSearch -eq $false -and $LetterSplitSearch -eq $false) {
+
+            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+        }
+        elseif ($SplitSearch -eq $true) {
+            # Get top-level containers
+            Write-Output "[*] Discovering top level containers for $Server..."
+            $topLevelContainers = Get-TopLevelContainers -Params $getAdObjectParams
+            if ($null -eq $topLevelContainers) {
+                Write-Error '[-] Something went wrong, no top-level containers found.'
+                return
+            }
+
+            # We also need to query specifically the domain object
+            $dcSearchParams = @{
+                Properties = '*'
+                LdapFilter = '(objectClass=domain)'
+            }
+
+            if ($Server) { $dcSearchParams['Server'] = $Server }
+            if ($Credential) { $dcSearchParams['Credential'] = $Credential }
+
+            Perform-ADQuery -SearchParams $dcSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
                         
-                    # In letter split search we need to make sure the top level containers are included
-                    if ($LetterSplitSearch -eq $true) {
-                        $topLevelContainers | ForEach-Object {
-                            Process-AdObject -AdObject $_ -StreamWriter $streamWriter
-                            $count.Value++
-                            if ($count.Value % $printingThreshold -eq 0) {
-                                Write-Output "[+] Queried $($Count.Value) objects so far..."
-                                $streamWriter.Flush()
-                            }
-                        }
-
-
+            # In letter split search we need to make sure the top level containers are included
+            if ($LetterSplitSearch -eq $true) {
+                $topLevelContainers | ForEach-Object {
+                    Process-AdObject -AdObject $_ -StreamWriter $streamWriter
+                    $count.Value++
+                    if ($count.Value % $printingThreshold -eq 0) {
+                        Write-Output "[+] Queried $($Count.Value) objects so far..."
+                        $streamWriter.Flush()
                     }
+                }
 
 
-                    Write-Output "[+] Found $($topLevelContainers.Count) top-level containers."
+            }
 
-                    $processedContainers = @()
-                    $unprocessedContainers = @()
 
-                    if ($ParsedContainers) {
-                        $ParsedContainersList = Get-Content -Path $ParsedContainers
-                    }
-                    else {
-                        $ParsedContainersList = @()
-                    }
+            Write-Output "[+] Found $($topLevelContainers.Count) top-level containers."
 
-                    $isFirstContainer = $true
-                    foreach ($container in $topLevelContainers) {
-                        $containerDN = $container.DistinguishedName
+            $processedContainers = @()
+            $unprocessedContainers = @()
 
-                        # Skip containers from ParsedContainers file
-                        if ($ParsedContainersList -contains $containerDN) {
-                            Write-Output "[+] Encountered already parsed container $containerDN, skipping..."
-                            $processedContainers += $containerDN
-                            continue
-                        }
+            if ($ParsedContainers) {
+                $ParsedContainersList = Get-Content -Path $ParsedContainers
+            }
+            else {
+                $ParsedContainersList = @()
+            }
+
+            $isFirstContainer = $true
+            foreach ($container in $topLevelContainers) {
+                $containerDN = $container.DistinguishedName
+
+                # Skip containers from ParsedContainers file
+                if ($ParsedContainersList -contains $containerDN) {
+                    Write-Output "[+] Encountered already parsed container $containerDN, skipping..."
+                    $processedContainers += $containerDN
+                    continue
+                }
                 
-                        # Skip already completed containers from state file
-                        if ($stateEnabled -and $stateData -and $stateData.completedContainers -contains $containerDN) {
-                            Write-Output "[+] Container $containerDN already completed, skipping..."
-                            $processedContainers += $containerDN
-                            continue
-                        }
+                # Skip already completed containers from state file
+                if ($stateEnabled -and $stateData -and $stateData.completedContainers -contains $containerDN) {
+                    Write-Output "[+] Container $containerDN already completed, skipping..."
+                    $processedContainers += $containerDN
+                    continue
+                }
 
-                        $containerSearchParams = $getAdObjectParams.Clone()
-                        $containerSearchParams['SearchBase'] = $containerDN
+                $containerSearchParams = $getAdObjectParams.Clone()
+                $containerSearchParams['SearchBase'] = $containerDN
 
-                        Write-Output "[*] Processing container ($($processedContainers.Count + $unprocessedContainers.Count + 1)/$($topLevelContainers.Count)): $containerDN"
+                Write-Output "[*] Processing container ($($processedContainers.Count + $unprocessedContainers.Count + 1)/$($topLevelContainers.Count)): $containerDN"
 
-                        if ($LetterSplitSearch -eq $false) {
-                            try {
-                                # Process the container
-                                Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                $processedContainers += $containerDN
+                if ($LetterSplitSearch -eq $false) {
+                    try {
+                        # Process the container
+                        Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                        $processedContainers += $containerDN
                         
-                                # Checkpoint after successful container query
-                                if ($stateEnabled -and $stateData) {
-                                    $stateData.completedContainers += $containerDN
-                                    $stateData.objectCount = $count.Value
-                                    Write-StateFile -State $stateData -Path $statePath
-                                }
-                            }
-                            catch {
-                                Write-Error "[-] Error processing container '$containerDN': $_"
-                                $unprocessedContainers += $containerDN
-                                continue
-                            }
-                        }
-                        elseif ($LetterSplitSearch -eq $true) {
-
-                            # Split the search by first letter
-                            # Top-level charset excludes . and - to avoid garbage queries
-                            $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
-                            # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
-                            $charsetFull = $charset + '.', '-'
-                            $OriginalFilter = $containerSearchParams['LdapFilter']
-                    
-                            # Determine starting letter for this container
-                            $startIdx = 0
-                            if ($stateEnabled -and $stateData -and $stateData.currentContainer -eq $containerDN -and $stateData.completedLetters) {
-                                # Resuming this container - use completed letters from state
-                                $completedSet = @($stateData.completedLetters)
-                            }
-                            elseif ($StartFromLetter -and $isFirstContainer) {
-                                # User specified starting letter - apply only to first container
-                                $completedSet = @()
-                                for ($i = 0; $i -lt $charset.Length; $i++) {
-                                    if ($charset[$i] -eq $StartFromLetter[0]) {
-                                        $startIdx = $i
-                                        break
-                                    }
-                                }
-                            }
-                            else {
-                                $completedSet = @()
-                            }
-                    
-                            foreach ($char in $charset[$startIdx..($charset.Length - 1)]) {
-                                $charStr = [string]$char
-                        
-                                # Skip if already completed
-                                if ($completedSet -contains $charStr) {
-                                    Write-Output "  [+] Letter '$charStr' already completed, skipping..."
-                                    continue
-                                }
-                        
-                                # Check if we have any subletters starting with this letter already completed
-                                $hasSubletters = $false
-                                foreach ($completed in $completedSet) {
-                                    if ($completed.Length -eq 2 -and $completed[0] -eq $char) {
-                                        $hasSubletters = $true
-                                        break
-                                    }
-                                }
-                        
-                                # Handle cases where we need to skip single letter and enumerate subletters:
-                                # 1. -StartFromLetter with 2-char prefix
-                                # 2. We have subletters in completedSet (resume scenario)
-                                if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
-                                    $subStartIdx = 0
-                            
-                                    # Determine starting subletter index
-                                    if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
-                                        # User specified a starting subletter
-                                        for ($i = 0; $i -lt $charset.Length; $i++) {
-                                            if ($charset[$i] -eq $StartFromLetter[1]) {
-                                                $subStartIdx = $i
-                                                break
-                                            }
-                                        }
-                                        Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
-                                    }
-                            
-                                    $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length - 1)]
-                                    foreach ($subChar in $subCharset) {
-                                        $doubleChar = "$charStr$subChar"
-                                
-                                        $isRetry = $false
-                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
-                                            $isRetry = $true
-                                            Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
-                                        }
-                                
-                                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
-                                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
-                                            continue
-                                        }
-                                
-                                        try {
-                                            Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
-                                            $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
-                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                    
-                                            # Checkpoint after successful subletter query
-                                            if ($stateEnabled -and $stateData) {
-                                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
-                                                    $stateData.completedLetters += $doubleChar
-                                                }
-                                        
-                                                if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
-                                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
-                                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
-                                                        $stateData.failedLetters.Remove($containerDN)
-                                                    }
-                                                }
-                                        
-                                                $stateData.currentContainer = $containerDN
-                                                $stateData.objectCount = $count.Value
-                                                Write-StateFile -State $stateData -Path $statePath
-                                            }
-                                        }
-                                        catch {
-                                            Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
-                                    
-                                            # Track failed letter for this container
-                                            if ($stateEnabled -and $stateData) {
-                                                if (-not $stateData.failedLetters[$containerDN]) {
-                                                    $stateData.failedLetters[$containerDN] = @()
-                                                }
-                                                if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
-                                                    $stateData.failedLetters[$containerDN] += $doubleChar
-                                                }
-                                                $stateData.objectCount = $count.Value
-                                                Write-StateFile -State $stateData -Path $statePath
-                                            }
-                                            continue
-                                        }
-                                    }
-                                    continue
-                                }
-                        
-                                Write-Output "  [*] Querying $containerDN for objects with CN starting with '$charStr'"
-                                $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr*))"
-
-                                try {
-                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                            
-                                    # Checkpoint after successful query
-                                    if ($stateEnabled -and $stateData) {
-                                        $stateData.completedLetters += $charStr
-                                        $stateData.currentContainer = $containerDN
-                                        $stateData.objectCount = $count.Value
-                                        Write-StateFile -State $stateData -Path $statePath
-                                    }
-                                }
-                                catch {
-                                    Write-Output "   [!!] Error processing CN=$charStr* for container '$containerDN': $_`nTrying to split each letter again..."
-                                    $subCharset = $charset
-                                    foreach ($subChar in $subCharset) {
-                                        $doubleChar = "$charStr$subChar"
-                                
-                                        $isRetry = $false
-                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
-                                            $isRetry = $true
-                                            Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
-                                        }
-                                
-                                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
-                                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
-                                            continue
-                                        }
-                                
-                                        try {
-                                            Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
-                                            $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
-                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                    
-                                            # Checkpoint after successful subletter query
-                                            if ($stateEnabled -and $stateData) {
-                                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
-                                                    $stateData.completedLetters += $doubleChar
-                                                }
-                                        
-                                                if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
-                                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
-                                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
-                                                        $stateData.failedLetters.Remove($containerDN)
-                                                    }
-                                                }
-                                        
-                                                $stateData.currentContainer = $containerDN
-                                                $stateData.objectCount = $count.Value
-                                                Write-StateFile -State $stateData -Path $statePath
-                                            }
-                                        }
-                                        catch {
-                                            Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
-                                    
-                                            # Track failed letter for this container
-                                            if ($stateEnabled -and $stateData) {
-                                                if (-not $stateData.failedLetters[$containerDN]) {
-                                                    $stateData.failedLetters[$containerDN] = @()
-                                                }
-                                                if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
-                                                    $stateData.failedLetters[$containerDN] += $doubleChar
-                                                }
-                                                $stateData.objectCount = $count.Value
-                                                Write-StateFile -State $stateData -Path $statePath
-                                            }
-                                            continue
-                                        }
-                                    }
-                                }
-                            }
-
-                            $processedContainers += $containerDN
-                            $isFirstContainer = $false
-                    
-                            if ($stateEnabled -and $stateData) {
-                                $stateData.completedContainers += $containerDN
-                                $stateData.completedLetters = @()
-                                $stateData.currentContainer = $null
-                                Write-StateFile -State $stateData -Path $statePath
-                            }
+                        # Checkpoint after successful container query
+                        if ($stateEnabled -and $stateData) {
+                            $stateData.completedContainers += $containerDN
+                            $stateData.objectCount = $count.Value
+                            Write-StateFile -State $stateData -Path $statePath
                         }
                     }
-
-                    # Output summary
-                    Write-Output "Processed $($count.Value) objects in total."
-                    if ($processedContainers.Count -gt 0) {
-                        Write-Output '[+] Successfully processed containers:'
-                        $processedContainers | ForEach-Object { Write-Output "  - $_" }
-                    }
-                    if ($unprocessedContainers.Count -gt 0) {
-                        Write-Output "`n[-] Failed to process containers:"
-                        $unprocessedContainers | ForEach-Object { Write-Output "    - $_" }
-                    }
-            
-                    # Report failed letters if any
-                    if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
-                        Write-Output ''
-                        Write-Output "[!] WARNING: Failed to enumerate letters for the following containers:"
-                        Write-Output ''
-                        foreach ($container in $stateData.failedLetters.Keys) {
-                            $letters = $stateData.failedLetters[$container] -join ', '
-                            Write-Output "  Container: $container"
-                            Write-Output "  Failed letters: $letters"
-                            Write-Output ''
-                        }
-                        Write-Output "[!] Partial or no data written for these letters before failure."
-                        Write-Output "[!] State file preserved. Resuming will retry failed letters."
-                        Write-Output ''
-                        Write-Output "[!] If failures persist, try these manual enumeration strategies:"
-                        Write-Output ''
-                        Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
-                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
-                        Write-Output "    # Targets specific year instead of broad '20*' pattern"
-                        Write-Output ''
-                        Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
-                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<failed-container-DN>' -OutputFilePath <output>"
-                        Write-Output "    # Enumerate one level deeper to reduce object count per query"
-                        Write-Output ''
-                        Write-Output "  Option 3 - Combine filters and letter splitting:"
-                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
-                        Write-Output "    # Narrow the pattern and still use letter splitting for safety"
-                        Write-Output ''
+                    catch {
+                        Write-Error "[-] Error processing container '$containerDN': $_"
+                        $unprocessedContainers += $containerDN
+                        continue
                     }
                 }
-                elseif ($LetterSplitSearch -eq $true -and $SplitSearch -eq $false) {
+                elseif ($LetterSplitSearch -eq $true) {
+
+                    # Split the search by first letter
                     # Top-level charset excludes . and - to avoid garbage queries
                     $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
                     # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
                     $charsetFull = $charset + '.', '-'
-                    $OriginalFilter = $getAdObjectParams['LdapFilter']
-                    $globalKey = 'global'
-            
+                    $OriginalFilter = $containerSearchParams['LdapFilter']
+                    
+                    # Determine starting letter for this container
                     $startIdx = 0
-                    $completedSet = @()
-                    if ($stateEnabled -and $stateData -and $stateData.completedLetters) {
+                    if ($stateEnabled -and $stateData -and $stateData.currentContainer -eq $containerDN -and $stateData.completedLetters) {
+                        # Resuming this container - use completed letters from state
                         $completedSet = @($stateData.completedLetters)
                     }
-                    elseif ($StartFromLetter) {
+                    elseif ($StartFromLetter -and $isFirstContainer) {
+                        # User specified starting letter - apply only to first container
+                        $completedSet = @()
                         for ($i = 0; $i -lt $charset.Length; $i++) {
                             if ($charset[$i] -eq $StartFromLetter[0]) {
                                 $startIdx = $i
@@ -664,16 +399,19 @@ function ShadowHound-ADM {
                             }
                         }
                     }
-            
+                    else {
+                        $completedSet = @()
+                    }
+                    
                     foreach ($char in $charset[$startIdx..($charset.Length - 1)]) {
                         $charStr = [string]$char
-                
+                        
                         # Skip if already completed
                         if ($completedSet -contains $charStr) {
                             Write-Output "  [+] Letter '$charStr' already completed, skipping..."
                             continue
                         }
-                
+                        
                         # Check if we have any subletters starting with this letter already completed
                         $hasSubletters = $false
                         foreach ($completed in $completedSet) {
@@ -682,13 +420,13 @@ function ShadowHound-ADM {
                                 break
                             }
                         }
-                
+                        
                         # Handle cases where we need to skip single letter and enumerate subletters:
                         # 1. -StartFromLetter with 2-char prefix
                         # 2. We have subletters in completedSet (resume scenario)
                         if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
                             $subStartIdx = 0
-                    
+                            
                             # Determine starting subletter index
                             if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
                                 # User specified a starting subletter
@@ -700,196 +438,55 @@ function ShadowHound-ADM {
                                 }
                                 Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
                             }
-                    
+                            
                             $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length - 1)]
                             foreach ($subChar in $subCharset) {
                                 $doubleChar = "$charStr$subChar"
+                                
                                 $isRetry = $false
-                        
-                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
                                     $isRetry = $true
-                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
+                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
                                 }
-                        
+                                
                                 if (($completedSet -contains $doubleChar) -and -not $isRetry) {
                                     Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
                                     continue
                                 }
-                        
-                                $hasTripleLetters = $false
-                                foreach ($completed in $completedSet) {
-                                    if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
-                                        $hasTripleLetters = $true
-                                        break
-                                    }
-                                }
-                        
-                                if ($hasTripleLetters) {
-                                    Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
-                            
-                                    # Iterate all 3-letter combinations for this 2-letter prefix
-                                    foreach ($tripleChar in $charsetFull) {
-                                        $triplePrefix = "$doubleChar$tripleChar"
                                 
-                                        # Check if already completed
-                                        if ($completedSet -contains $triplePrefix) {
-                                            Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
-                                            continue
-                                        }
-                                
-                                        # Check if in failedLetters and needs retry
-                                        $isFailedRetry = $false
-                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
-                                            $isFailedRetry = $true
-                                            Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
-                                        }
-                                
-                                        if ($isFailedRetry) {
-                                            try {
-                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                        
-                                                # Success - add to completed, remove from failed
-                                                if ($stateEnabled -and $stateData) {
-                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                        $stateData.completedLetters += $triplePrefix
-                                                    }
-                                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
-                                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                                        $stateData.failedLetters.Remove($globalKey)
-                                                    }
-                                                    $stateData.objectCount = $count.Value
-                                                    Write-StateFile -State $stateData -Path $statePath
-                                                }
-                                                Write-Output "      [+] Successfully retried '$triplePrefix'"
-                                            }
-                                            catch {
-                                                Write-Output "      [-] Retry failed for '$triplePrefix': $_"
-                                                # Keep in failedLetters for future retry
-                                            }
-                                        }
-                                    }
-                            
-                                    continue
-                                }
-                        
                                 try {
-                                    Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
-                                    $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
-                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                            
+                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
+                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
+                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    
                                     # Checkpoint after successful subletter query
                                     if ($stateEnabled -and $stateData) {
                                         if (-not ($stateData.completedLetters -contains $doubleChar)) {
                                             $stateData.completedLetters += $doubleChar
                                         }
-                                
-                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                                $stateData.failedLetters.Remove($globalKey)
+                                        
+                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($containerDN)
                                             }
                                         }
-                                
+                                        
+                                        $stateData.currentContainer = $containerDN
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
                                 }
                                 catch {
-                                    Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
-                                    Write-Output '       Trying to split to 3-letter prefixes...'
-                            
-                                    $batchSize = 4
-                                    $tripleSuccess = $false
-                                    $failedBatches = @()
-                            
-                                    for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
-                                        $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
-                                        $batch = $charsetFull[$batchIdx..$batchEnd]
-                                
-                                        $orFilters = @()
-                                        foreach ($tripleChar in $batch) {
-                                            $triplePrefix = "$doubleChar$tripleChar"
-                                            $orFilters += "(cn=$triplePrefix*)"
-                                        }
-                                
-                                        $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
-                                        $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
-                                
-                                        try {
-                                            Write-Output "  [*] Querying batch: $batchNames"
-                                            $getAdObjectParams['LdapFilter'] = $batchFilter
-                                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                            $tripleSuccess = $true
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
                                     
-                                            if ($stateEnabled -and $stateData) {
-                                                foreach ($tripleChar in $batch) {
-                                                    $triplePrefix = "$doubleChar$tripleChar"
-                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                        $stateData.completedLetters += $triplePrefix
-                                                    }
-                                                }
-                                                $stateData.objectCount = $count.Value
-                                                Write-StateFile -State $stateData -Path $statePath
-                                            }
+                                    # Track failed letter for this container
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$containerDN]) {
+                                            $stateData.failedLetters[$containerDN] = @()
                                         }
-                                        catch {
-                                            Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
-                                            $failedBatches += , @($batch)
-                                        }
-                                    }
-                            
-                                    foreach ($batch in $failedBatches) {
-                                        foreach ($tripleChar in $batch) {
-                                            $triplePrefix = "$doubleChar$tripleChar"
-                                    
-                                            try {
-                                                Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
-                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                                $tripleSuccess = $true
-                                        
-                                                if ($stateEnabled -and $stateData) {
-                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                        $stateData.completedLetters += $triplePrefix
-                                                    }
-                                                    $stateData.objectCount = $count.Value
-                                                    Write-StateFile -State $stateData -Path $statePath
-                                                }
-                                            }
-                                            catch {
-                                                Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
-                                        
-                                                if ($stateEnabled -and $stateData) {
-                                                    if (-not $stateData.failedLetters[$globalKey]) {
-                                                        $stateData.failedLetters[$globalKey] = @()
-                                                    }
-                                                    if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
-                                                        $stateData.failedLetters[$globalKey] += $triplePrefix
-                                                    }
-                                                    $stateData.objectCount = $count.Value
-                                                    Write-StateFile -State $stateData -Path $statePath
-                                                }
-                                                continue
-                                            }
-                                        }
-                                    }
-                            
-                                    if ($tripleSuccess -and $stateEnabled -and $stateData) {
-                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                                $stateData.failedLetters.Remove($globalKey)
-                                            }
-                                            Write-StateFile -State $stateData -Path $statePath
-                                        }
-                                    }
-                                    elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
-                                        if (-not $stateData.failedLetters[$globalKey]) {
-                                            $stateData.failedLetters[$globalKey] = @()
-                                        }
-                                        if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
-                                            $stateData.failedLetters[$globalKey] += $doubleChar
+                                        if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] += $doubleChar
                                         }
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
@@ -899,212 +496,71 @@ function ShadowHound-ADM {
                             }
                             continue
                         }
-                
-                        Write-Output "  [*] Querying for objects with CN starting with '$charStr'"
-                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
+                        
+                        Write-Output "  [*] Querying $containerDN for objects with CN starting with '$charStr'"
+                        $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr*))"
 
                         try {
-                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                    
+                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
                             # Checkpoint after successful query
                             if ($stateEnabled -and $stateData) {
                                 $stateData.completedLetters += $charStr
+                                $stateData.currentContainer = $containerDN
                                 $stateData.objectCount = $count.Value
                                 Write-StateFile -State $stateData -Path $statePath
                             }
                         }
                         catch {
-                            Write-Output "   [!!] Error processing character '$charStr*': $_"
-                            Write-Output '        Trying to split each letter again...'
-                            $subCharset = $charsetFull
+                            Write-Output "   [!!] Error processing CN=$charStr* for container '$containerDN': $_`nTrying to split each letter again..."
+                            $subCharset = $charset
                             foreach ($subChar in $subCharset) {
                                 $doubleChar = "$charStr$subChar"
+                                
                                 $isRetry = $false
-                        
-                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
                                     $isRetry = $true
-                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
+                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
                                 }
-                        
+                                
                                 if (($completedSet -contains $doubleChar) -and -not $isRetry) {
                                     Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
                                     continue
                                 }
-                        
-                                $hasTripleLetters = $false
-                                foreach ($completed in $completedSet) {
-                                    if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
-                                        $hasTripleLetters = $true
-                                        break
-                                    }
-                                }
-                        
-                                if ($hasTripleLetters) {
-                                    Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
-                            
-                                    # Iterate all 3-letter combinations for this 2-letter prefix
-                                    foreach ($tripleChar in $charsetFull) {
-                                        $triplePrefix = "$doubleChar$tripleChar"
                                 
-                                        # Check if already completed
-                                        if ($completedSet -contains $triplePrefix) {
-                                            Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
-                                            continue
-                                        }
-                                
-                                        # Check if in failedLetters and needs retry
-                                        $isFailedRetry = $false
-                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
-                                            $isFailedRetry = $true
-                                            Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
-                                        }
-                                
-                                        if ($isFailedRetry) {
-                                            try {
-                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                        
-                                                # Success - add to completed, remove from failed
-                                                if ($stateEnabled -and $stateData) {
-                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                        $stateData.completedLetters += $triplePrefix
-                                                    }
-                                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
-                                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                                        $stateData.failedLetters.Remove($globalKey)
-                                                    }
-                                                    $stateData.objectCount = $count.Value
-                                                    Write-StateFile -State $stateData -Path $statePath
-                                                }
-                                                Write-Output "      [+] Successfully retried '$triplePrefix'"
-                                            }
-                                            catch {
-                                                Write-Output "      [-] Retry failed for '$triplePrefix': $_"
-                                                # Keep in failedLetters for future retry
-                                            }
-                                        }
-                                    }
-                            
-                                    continue
-                                }
-                        
                                 try {
-                                    Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
-                                    $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
-                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                            
+                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
+                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
+                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    
                                     # Checkpoint after successful subletter query
                                     if ($stateEnabled -and $stateData) {
                                         if (-not ($stateData.completedLetters -contains $doubleChar)) {
                                             $stateData.completedLetters += $doubleChar
                                         }
-                                
-                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                                $stateData.failedLetters.Remove($globalKey)
+                                        
+                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($containerDN)
                                             }
                                         }
-                                
+                                        
+                                        $stateData.currentContainer = $containerDN
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
                                 }
                                 catch {
-                                    Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
-                                    Write-Output '       Trying to split to 3-letter prefixes...'
-                            
-                                    $batchSize = 4
-                                    $tripleSuccess = $false
-                                    $failedBatches = @()
-                            
-                                    for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
-                                        $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
-                                        $batch = $charsetFull[$batchIdx..$batchEnd]
-                                
-                                        $orFilters = @()
-                                        foreach ($tripleChar in $batch) {
-                                            $triplePrefix = "$doubleChar$tripleChar"
-                                            $orFilters += "(cn=$triplePrefix*)"
-                                        }
-                                
-                                        $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
-                                        $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
-                                
-                                        try {
-                                            Write-Output "  [*] Querying batch: $batchNames"
-                                            $getAdObjectParams['LdapFilter'] = $batchFilter
-                                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                            $tripleSuccess = $true
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
                                     
-                                            if ($stateEnabled -and $stateData) {
-                                                foreach ($tripleChar in $batch) {
-                                                    $triplePrefix = "$doubleChar$tripleChar"
-                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                        $stateData.completedLetters += $triplePrefix
-                                                    }
-                                                }
-                                                $stateData.objectCount = $count.Value
-                                                Write-StateFile -State $stateData -Path $statePath
-                                            }
+                                    # Track failed letter for this container
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$containerDN]) {
+                                            $stateData.failedLetters[$containerDN] = @()
                                         }
-                                        catch {
-                                            Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
-                                            $failedBatches += , @($batch)
-                                        }
-                                    }
-                            
-                                    foreach ($batch in $failedBatches) {
-                                        foreach ($tripleChar in $batch) {
-                                            $triplePrefix = "$doubleChar$tripleChar"
-                                    
-                                            try {
-                                                Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
-                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                                $tripleSuccess = $true
-                                        
-                                                if ($stateEnabled -and $stateData) {
-                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                        $stateData.completedLetters += $triplePrefix
-                                                    }
-                                                    $stateData.objectCount = $count.Value
-                                                    Write-StateFile -State $stateData -Path $statePath
-                                                }
-                                            }
-                                            catch {
-                                                Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
-                                        
-                                                if ($stateEnabled -and $stateData) {
-                                                    if (-not $stateData.failedLetters[$globalKey]) {
-                                                        $stateData.failedLetters[$globalKey] = @()
-                                                    }
-                                                    if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
-                                                        $stateData.failedLetters[$globalKey] += $triplePrefix
-                                                    }
-                                                    $stateData.objectCount = $count.Value
-                                                    Write-StateFile -State $stateData -Path $statePath
-                                                }
-                                                continue
-                                            }
-                                        }
-                                    }
-                            
-                                    if ($tripleSuccess -and $stateEnabled -and $stateData) {
-                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                                $stateData.failedLetters.Remove($globalKey)
-                                            }
-                                            Write-StateFile -State $stateData -Path $statePath
-                                        }
-                                    }
-                                    elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
-                                        if (-not $stateData.failedLetters[$globalKey]) {
-                                            $stateData.failedLetters[$globalKey] = @()
-                                        }
-                                        if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
-                                            $stateData.failedLetters[$globalKey] += $doubleChar
+                                        if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] += $doubleChar
                                         }
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
@@ -1114,93 +570,679 @@ function ShadowHound-ADM {
                             }
                         }
                     }
+
+                    $processedContainers += $containerDN
+                    $isFirstContainer = $false
+                    
+                    if ($stateEnabled -and $stateData) {
+                        $stateData.completedContainers += $containerDN
+                        $stateData.completedLetters = @()
+                        $stateData.currentContainer = $null
+                        Write-StateFile -State $stateData -Path $statePath
+                    }
+                }
+            }
+
+            # Output summary
+            Write-Output "Processed $($count.Value) objects in total."
+            if ($processedContainers.Count -gt 0) {
+                # Silent success
+            }
+            if ($unprocessedContainers.Count -gt 0) {
+                Write-Output "`n[-] Failed to process containers:"
+                $unprocessedContainers | ForEach-Object { Write-Output "    - $_" }
+            }
             
-                    if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
-                        Write-Output ''
-                        Write-Output "[!] WARNING: Failed to enumerate the following letters:"
-                        if ($stateData.failedLetters[$globalKey]) {
-                            $letters = $stateData.failedLetters[$globalKey] -join ', '
-                            Write-Output "  Failed letters: $letters"
+            # Report failed letters if any
+            if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                Write-Output ''
+                Write-Output "[!] WARNING: Failed to enumerate letters for the following containers:"
+                Write-Output ''
+                foreach ($container in $stateData.failedLetters.Keys) {
+                    $letters = $stateData.failedLetters[$container] -join ', '
+                    Write-Output "  Container: $container"
+                    Write-Output "  Failed letters: $letters"
+                    Write-Output ''
+                }
+                Write-Output "[!] Partial or no data written for these letters before failure."
+                Write-Output "[!] State file preserved. Resuming will retry failed letters."
+                Write-Output ''
+                Write-Output "[!] If failures persist, try these manual enumeration strategies:"
+                Write-Output ''
+                Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
+                Write-Output "    # Targets specific year instead of broad '20*' pattern"
+                Write-Output ''
+                Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<failed-container-DN>' -OutputFilePath <output>"
+                Write-Output "    # Enumerate one level deeper to reduce object count per query"
+                Write-Output ''
+                Write-Output "  Option 3 - Combine filters and letter splitting:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
+                Write-Output "    # Narrow the pattern and still use letter splitting for safety"
+                Write-Output ''
+            }
+        }
+        elseif ($LetterSplitSearch -eq $true -and $SplitSearch -eq $false) {
+            # Top-level charset excludes . and - to avoid garbage queries
+            $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
+            # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
+            $charsetFull = $charset + '.', '-'
+            $OriginalFilter = $getAdObjectParams['LdapFilter']
+            $globalKey = 'global'
+            
+            $startIdx = 0
+            $completedSet = @()
+            if ($stateEnabled -and $stateData -and $stateData.completedLetters) {
+                $completedSet = @($stateData.completedLetters)
+            }
+            elseif ($StartFromLetter) {
+                for ($i = 0; $i -lt $charset.Length; $i++) {
+                    if ($charset[$i] -eq $StartFromLetter[0]) {
+                        $startIdx = $i
+                        break
+                    }
+                }
+            }
+            
+            foreach ($char in $charset[$startIdx..($charset.Length - 1)]) {
+                $charStr = [string]$char
+                
+                # Skip if already completed
+                if ($completedSet -contains $charStr) {
+                    Write-Output "  [+] Letter '$charStr' already completed, skipping..."
+                    continue
+                }
+                
+                # Check if we have any subletters starting with this letter already completed
+                $hasSubletters = $false
+                foreach ($completed in $completedSet) {
+                    if ($completed.Length -eq 2 -and $completed[0] -eq $char) {
+                        $hasSubletters = $true
+                        break
+                    }
+                }
+                
+                # Handle cases where we need to skip single letter and enumerate subletters:
+                # 1. -StartFromLetter with 2-char prefix
+                # 2. We have subletters in completedSet (resume scenario)
+                if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
+                    $subStartIdx = 0
+                    
+                    # Determine starting subletter index
+                    if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
+                        # User specified a starting subletter
+                        for ($i = 0; $i -lt $charset.Length; $i++) {
+                            if ($charset[$i] -eq $StartFromLetter[1]) {
+                                $subStartIdx = $i
+                                break
+                            }
                         }
-                        Write-Output ''
-                        Write-Output "[!] Partial or no data written for these letters before failure."
-                        Write-Output "[!] State file preserved. Resuming will retry failed letters."
-                        Write-Output ''
-                        Write-Output "[!] If failures persist, try these manual enumeration strategies:"
-                        Write-Output ''
-                        Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
-                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
-                        Write-Output "    # Targets specific year instead of broad '20*' pattern"
-                        Write-Output ''
-                        Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
-                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<search-base>' -OutputFilePath <output>"
-                        Write-Output "    # Enumerate one level deeper to reduce object count per query"
-                        Write-Output ''
-                        Write-Output "  Option 3 - Combine filters and letter splitting:"
-                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
-                        Write-Output "    # Narrow the pattern and still use letter splitting for safety"
-                        Write-Output ''
+                        Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
+                    }
+                    
+                    $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length - 1)]
+                    foreach ($subChar in $subCharset) {
+                        $doubleChar = "$charStr$subChar"
+                        $isRetry = $false
+                        
+                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                            $isRetry = $true
+                            Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
+                        }
+                        
+                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                            continue
+                        }
+                        
+                        $hasTripleLetters = $false
+                        foreach ($completed in $completedSet) {
+                            if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
+                                $hasTripleLetters = $true
+                                break
+                            }
+                        }
+                        
+                        if ($hasTripleLetters) {
+                            Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
+                            
+                            # Iterate all 3-letter combinations for this 2-letter prefix
+                            foreach ($tripleChar in $charsetFull) {
+                                $triplePrefix = "$doubleChar$tripleChar"
+                                
+                                # Check if already completed
+                                if ($completedSet -contains $triplePrefix) {
+                                    Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
+                                    continue
+                                }
+                                
+                                # Check if in failedLetters and needs retry
+                                $isFailedRetry = $false
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                    $isFailedRetry = $true
+                                    Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
+                                }
+                                
+                                if ($isFailedRetry) {
+                                    try {
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        
+                                        # Success - add to completed, remove from failed
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($globalKey)
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        Write-Output "      [+] Successfully retried '$triplePrefix'"
+                                    }
+                                    catch {
+                                        Write-Output "      [-] Retry failed for '$triplePrefix': $_"
+                                        # Keep in failedLetters for future retry
+                                    }
+                                }
+                            }
+                            
+                            continue
+                        }
+                        
+                        try {
+                            Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
+                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
+                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
+                            # Checkpoint after successful subletter query
+                            if ($stateEnabled -and $stateData) {
+                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                    $stateData.completedLetters += $doubleChar
+                                }
+                                
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                }
+                                
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                        }
+                        catch {
+                            Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
+                            Write-Output '       Trying to split to 3-letter prefixes...'
+                            
+                            $batchSize = 4
+                            $tripleSuccess = $false
+                            $failedBatches = @()
+                            
+                            for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                $batch = $charsetFull[$batchIdx..$batchEnd]
+                                
+                                $orFilters = @()
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    $orFilters += "(cn=$triplePrefix*)"
+                                }
+                                
+                                $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+                                
+                                try {
+                                    Write-Output "  [*] Querying batch: $batchNames"
+                                    $getAdObjectParams['LdapFilter'] = $batchFilter
+                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    $tripleSuccess = $true
+                                    
+                                    if ($stateEnabled -and $stateData) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+
+                                            if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                                if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                    $stateData.failedLetters.Remove($globalKey)
+                                                }
+                                            }
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                }
+                                catch {
+                                    Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
+
+                                    # Crash-safe: record all triple prefixes in this failed batch for retry.
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$globalKey]) {
+                                            $stateData.failedLetters[$globalKey] = @()
+                                        }
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] += $triplePrefix
+                                            }
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                    $failedBatches += , @($batch)
+                                }
+                            }
+                            
+                            foreach ($batch in $failedBatches) {
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    
+                                    try {
+                                        Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        $tripleSuccess = $true
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+
+                                            if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                                if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                    $stateData.failedLetters.Remove($globalKey)
+                                                }
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    }
+                                    catch {
+                                        Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not $stateData.failedLetters[$globalKey]) {
+                                                $stateData.failedLetters[$globalKey] = @()
+                                            }
+                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] += $triplePrefix
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        continue
+                                    }
+                                }
+                            }
+                            
+                            if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                    Write-StateFile -State $stateData -Path $statePath
+                                }
+                            }
+                            elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
+                                if (-not $stateData.failedLetters[$globalKey]) {
+                                    $stateData.failedLetters[$globalKey] = @()
+                                }
+                                if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] += $doubleChar
+                                }
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                            continue
+                        }
+                    }
+                    continue
+                }
+                
+                Write-Output "  [*] Querying for objects with CN starting with '$charStr'"
+                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
+
+                try {
+                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                    
+                    # Checkpoint after successful query
+                    if ($stateEnabled -and $stateData) {
+                        $stateData.completedLetters += $charStr
+                        $stateData.objectCount = $count.Value
+                        Write-StateFile -State $stateData -Path $statePath
                     }
                 }
+                catch {
+                    Write-Output "   [!!] Error processing character '$charStr*': $_"
+                    Write-Output '        Trying to split each letter again...'
+                    $subCharset = $charsetFull
+                    foreach ($subChar in $subCharset) {
+                        $doubleChar = "$charStr$subChar"
+                        $isRetry = $false
+                        
+                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                            $isRetry = $true
+                            Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
+                        }
+                        
+                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                            continue
+                        }
+                        
+                        $hasTripleLetters = $false
+                        foreach ($completed in $completedSet) {
+                            if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
+                                $hasTripleLetters = $true
+                                break
+                            }
+                        }
+                        
+                        if ($hasTripleLetters) {
+                            Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
+                            
+                            # Iterate all 3-letter combinations for this 2-letter prefix
+                            foreach ($tripleChar in $charsetFull) {
+                                $triplePrefix = "$doubleChar$tripleChar"
+                                
+                                # Check if already completed
+                                if ($completedSet -contains $triplePrefix) {
+                                    Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
+                                    continue
+                                }
+                                
+                                # Check if in failedLetters and needs retry
+                                $isFailedRetry = $false
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                    $isFailedRetry = $true
+                                    Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
+                                }
+                                
+                                if ($isFailedRetry) {
+                                    try {
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        
+                                        # Success - add to completed, remove from failed
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($globalKey)
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        Write-Output "      [+] Successfully retried '$triplePrefix'"
+                                    }
+                                    catch {
+                                        Write-Output "      [-] Retry failed for '$triplePrefix': $_"
+                                        # Keep in failedLetters for future retry
+                                    }
+                                }
+                            }
+                            
+                            continue
+                        }
+                        
+                        try {
+                            Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
+                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
+                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
+                            # Checkpoint after successful subletter query
+                            if ($stateEnabled -and $stateData) {
+                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                    $stateData.completedLetters += $doubleChar
+                                }
+                                
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                }
+                                
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                        }
+                        catch {
+                            Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
+                            Write-Output '       Trying to split to 3-letter prefixes...'
+                            
+                            $batchSize = 4
+                            $tripleSuccess = $false
+                            $failedBatches = @()
+                            
+                            for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                $batch = $charsetFull[$batchIdx..$batchEnd]
+                                
+                                $orFilters = @()
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    $orFilters += "(cn=$triplePrefix*)"
+                                }
+                                
+                                $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+                                
+                                try {
+                                    Write-Output "  [*] Querying batch: $batchNames"
+                                    $getAdObjectParams['LdapFilter'] = $batchFilter
+                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    $tripleSuccess = $true
+                                    
+                                    if ($stateEnabled -and $stateData) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
 
+                                            if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                                if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                    $stateData.failedLetters.Remove($globalKey)
+                                                }
+                                            }
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                }
+                                catch {
+                                    Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
 
-                $summaryLine = "Retrieved $($count.Value) results total"
-                $streamWriter.WriteLine($summaryLine)
-            }
-            finally {
-                $streamWriter.Flush()
-                $streamWriter.Close()
-            }
+                                    # Crash-safe: record all triple prefixes in this failed batch for retry.
+                                    if ($stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$globalKey]) {
+                                            $stateData.failedLetters[$globalKey] = @()
+                                        }
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] += $triplePrefix
+                                            }
+                                        }
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                    $failedBatches += , @($batch)
+                                }
+                            }
+                            
+                            foreach ($batch in $failedBatches) {
+                                foreach ($tripleChar in $batch) {
+                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    
+                                    try {
+                                        Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
+                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        $tripleSuccess = $true
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                $stateData.completedLetters += $triplePrefix
+                                            }
 
-            # State cleanup on completion
-            if ($stateEnabled -and $statePath -and -not $KeepStateFile) {
-                # Only remove state file if no failures occurred
-                if ($stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
-                    Write-Output '[*] State file preserved due to failed letters:' $statePath
-                }
-                else {
-                    Write-Output '[*] Enumeration complete, removing state file...'
-                    Remove-StateFile -Path $statePath
-                }
-            }
-            elseif ($stateEnabled -and $KeepStateFile) {
-                Write-Output '[*] State file preserved:' $statePath
-            }
-
-            Write-Output "Objects have been processed and written to $OutputFilePath"
-            Write-Output $summaryLine
-            Write-Output '==================================================='
-
-            # Handle recursion if necessary
-            if ($Recurse -and $unprocessedContainers.Count -gt 0) {
-                Write-Output "[*] Current SearchBase is $SearchBase"
-                Write-Output "[*] Attempting to recurse $($unprocessedContainers.Count) failed containers/OUs:"
-                foreach ($failedContainer in $unprocessedContainers) {
-                    Write-Output $failedContainer
-
-                    $recurseParams = @{
-                        OutputFilePath = "$($failedContainer.Split(',')[0].Split('=')[1])_$OutputFilePath"
-                        SearchBase     = $failedContainer
-                        SplitSearch    = $true
-                        Recurse        = $true
+                                            if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                                if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                    $stateData.failedLetters.Remove($globalKey)
+                                                }
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    }
+                                    catch {
+                                        Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
+                                        
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not $stateData.failedLetters[$globalKey]) {
+                                                $stateData.failedLetters[$globalKey] = @()
+                                            }
+                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                $stateData.failedLetters[$globalKey] += $triplePrefix
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        continue
+                                    }
+                                }
+                            }
+                            
+                            if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($globalKey)
+                                    }
+                                    Write-StateFile -State $stateData -Path $statePath
+                                }
+                            }
+                            elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
+                                if (-not $stateData.failedLetters[$globalKey]) {
+                                    $stateData.failedLetters[$globalKey] = @()
+                                }
+                                if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
+                                    $stateData.failedLetters[$globalKey] += $doubleChar
+                                }
+                                $stateData.objectCount = $count.Value
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                            continue
+                        }
                     }
-                    if ($Server) { $recurseParams['Server'] = $Server }
-                    if ($Credential) { $recurseParams['Credential'] = $Credential }
-                    if ($ParsedContainers) { $recurseParams['ParsedContainers'] = $ParsedContainers }
-                    if ($LdapFilter) { $recurseParams['LdapFilter'] = $LdapFilter }
-
-                    if ($LetterSplitSearch) {
-                        $recurseParams['LetterSplitSearch'] = $true
-                    }
-
-                    Write-Output "[+] Attempting to recurse $failedContainer"
-                    ShadowHound-ADM @recurseParams
                 }
+            }
+            
+            if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                Write-Output ''
+                Write-Output "[!] WARNING: Failed to enumerate the following letters:"
+                if ($stateData.failedLetters[$globalKey]) {
+                    $letters = $stateData.failedLetters[$globalKey] -join ', '
+                    Write-Output "  Failed letters: $letters"
+                }
+                Write-Output ''
+                Write-Output "[!] Partial or no data written for these letters before failure."
+                Write-Output "[!] State file preserved. Resuming will retry failed letters."
+                Write-Output ''
+                Write-Output "[!] If failures persist, try these manual enumeration strategies:"
+                Write-Output ''
+                Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
+                Write-Output "    # Targets specific year instead of broad '20*' pattern"
+                Write-Output ''
+                Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<search-base>' -OutputFilePath <output>"
+                Write-Output "    # Enumerate one level deeper to reduce object count per query"
+                Write-Output ''
+                Write-Output "  Option 3 - Combine filters and letter splitting:"
+                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
+                Write-Output "    # Narrow the pattern and still use letter splitting for safety"
+                Write-Output ''
             }
         }
 
-        function Print-Logo {
-            $logo = @'
+
+        $summaryLine = "Retrieved $($count.Value) results total"
+        $streamWriter.WriteLine($summaryLine)
+    }
+    finally {
+        $streamWriter.Flush()
+        $streamWriter.Close()
+    }
+
+    # State cleanup on completion
+    if ($stateEnabled -and $statePath -and -not $KeepStateFile) {
+        # Only remove state file if no failures occurred (letter or container)
+        $hasFailures = ($stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) -or ($unprocessedContainers -and $unprocessedContainers.Count -gt 0)
+        
+        if ($hasFailures) {
+            Write-Output "[*] State file preserved due to failed items ($($unprocessedContainers.Count) containers, $($stateData.failedLetters.Count) letters): $statePath"
+        }
+        else {
+            Write-Output '[*] Enumeration complete, removing state file...'
+            Remove-StateFile -Path $statePath
+        }
+    }
+    elseif ($stateEnabled -and $KeepStateFile) {
+        Write-Output '[*] State file preserved:' $statePath
+    }
+
+    Write-Output "Objects have been processed and written to $OutputFilePath"
+    Write-Output $summaryLine
+    Write-Output '==================================================='
+
+
+    # Handle recursion if necessary
+    if ($Recurse -and $unprocessedContainers.Count -gt 0) {
+        Write-Output "[*] Current SearchBase is $SearchBase"
+        Write-Output "[*] Attempting to recurse $($unprocessedContainers.Count) failed containers/OUs:"
+        foreach ($failedContainer in $unprocessedContainers) {
+            Write-Output $failedContainer
+
+            $recurseParams = @{
+                OutputFilePath = "$($failedContainer.Split(',')[0].Split('=')[1])_$OutputFilePath"
+                SearchBase     = $failedContainer
+                SplitSearch    = $true
+                Recurse        = $true
+            }
+            if ($Server) { $recurseParams['Server'] = $Server }
+            if ($Credential) { $recurseParams['Credential'] = $Credential }
+            if ($ParsedContainers) { $recurseParams['ParsedContainers'] = $ParsedContainers }
+            if ($LdapFilter) { $recurseParams['LdapFilter'] = $LdapFilter }
+
+            if ($LetterSplitSearch) {
+                $recurseParams['LetterSplitSearch'] = $true
+            }
+
+
+            Write-Output "[+] Attempting to recurse $failedContainer"
+            ShadowHound-ADM @recurseParams
+        }
+    }
+}
+
+function Print-Logo {
+    $logo = @'
 .........................................................................
 :  ____  _               _               _   _                       _  :
 : / ___|| |__   __ _  __| | _____      _| | | | ___  _   _ _ __   __| | :
@@ -1211,12 +1253,12 @@ function ShadowHound-ADM {
 :   Author: Yehuda Smirnov (X: @yudasm_ BlueSky: @yudasm.bsky.social)   :
 .........................................................................
 '@
-            Write-Output $logo
-        }
+    Write-Output $logo
+}
 
-        function Print-Help {
-            Print-Logo
-            $helpMessage = '
+function Print-Help {
+    Print-Logo
+    $helpMessage = '
 ShadowHound-ADM Help
 
 SYNTAX:
@@ -1304,541 +1346,535 @@ EXAMPLES:
     # Example 8: Disable state file for zero artifacts
     ShadowHound-ADM -OutputFilePath "C:\Results\output.txt" -LetterSplitSearch -DisableStateFile
 '
-            Write-Host $helpMessage
-            return
+    Write-Host $helpMessage
+    return
+}
+
+function Process-AdObject {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.ActiveDirectory.Management.ADObject]$AdObject,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.StreamWriter]$StreamWriter
+    )
+
+    # Define ignored properties
+    $ignoredValues = @(
+        'CanonicalName', 'PropertyNames', 'AddedProperties', 'RemovedProperties',
+        'ModifiedProperties', 'PropertyCount', 'repsTo', 'ProtectedFromAccidentalDeletion',
+        'sDRightsEffective', 'modifyTimeStamp', 'Modified', 'createTimeStamp',
+        'Created', 'userCertificate'
+    )
+
+    # Map object classes
+    $objectClassMapping = @{
+        'applicationSettings'                  = 'top, applicationSettings, nTFRSSettings'
+        'builtinDomain'                        = 'top, builtinDomain'
+        'classStore'                           = 'top, classStore'
+        'container'                            = 'top, container'
+        'groupPolicyContainer'                 = 'top, container, groupPolicyContainer'
+        'msImaging-PSPs'                       = 'top, container, msImaging-PSPs'
+        'rpcContainer'                         = 'top, container, rpcContainer'
+        'dfsConfiguration'                     = 'top, dfsConfiguration'
+        'dnsNode'                              = 'top, dnsNode'
+        'dnsZone'                              = 'top, dnsZone'
+        'domainDNS'                            = 'top, domain, domainDNS'
+        'fileLinkTracking'                     = 'top, fileLinkTracking'
+        'linkTrackObjectMoveTable'             = 'top, fileLinkTracking, linkTrackObjectMoveTable'
+        'linkTrackVolumeTable'                 = 'top, fileLinkTracking, linkTrackVolumeTable'
+        'foreignSecurityPrincipal'             = 'top, foreignSecurityPrincipal'
+        'group'                                = 'top, group'
+        'infrastructureUpdate'                 = 'top, infrastructureUpdate'
+        'ipsecFilter'                          = 'top, ipsecBase, ipsecFilter'
+        'ipsecISAKMPPolicy'                    = 'top, ipsecBase, ipsecISAKMPPolicy'
+        'ipsecNegotiationPolicy'               = 'top, ipsecBase, ipsecNegotiationPolicy'
+        'ipsecNFA'                             = 'top, ipsecBase, ipsecNFA'
+        'ipsecPolicy'                          = 'top, ipsecBase, ipsecPolicy'
+        'domainPolicy'                         = 'top, leaf, domainPolicy'
+        'secret'                               = 'top, leaf, secret'
+        'trustedDomain'                        = 'top, leaf, trustedDomain'
+        'lostAndFound'                         = 'top, lostAndFound'
+        'msDFSR-Content'                       = 'top, msDFSR-Content'
+        'msDFSR-ContentSet'                    = 'top, msDFSR-ContentSet'
+        'msDFSR-GlobalSettings'                = 'top, msDFSR-GlobalSettings'
+        'msDFSR-LocalSettings'                 = 'top, msDFSR-LocalSettings'
+        'msDFSR-Member'                        = 'top, msDFSR-Member'
+        'msDFSR-ReplicationGroup'              = 'top, msDFSR-ReplicationGroup'
+        'msDFSR-Subscriber'                    = 'top, msDFSR-Subscriber'
+        'msDFSR-Subscription'                  = 'top, msDFSR-Subscription'
+        'msDFSR-Topology'                      = 'top, msDFSR-Topology'
+        'msDS-PasswordSettingsContainer'       = 'top, msDS-PasswordSettingsContainer'
+        'msDS-QuotaContainer'                  = 'top, msDS-QuotaContainer'
+        'msTPM-InformationObjectsContainer'    = 'top, msTPM-InformationObjectsContainer'
+        'organizationalUnit'                   = 'top, organizationalUnit'
+        'contact'                              = 'top, person, organizationalPerson, contact'
+        'user'                                 = 'top, person, organizationalPerson, user'
+        'computer'                             = 'top, person, organizationalPerson, user, computer'
+        'rIDManager'                           = 'top, rIDManager'
+        'rIDSet'                               = 'top, rIDSet'
+        'samServer'                            = 'top, securityObject, samServer'
+        'msExchSystemObjectsContainer'         = 'top, container, msExchSystemObjectsContainer'
+        'msRTCSIP-ApplicationContacts'         = 'top, container, msRTCSIP-ApplicationContacts'
+        'msRTCSIP-ArchivingServer'             = 'top, container, msRTCSIP-ArchivingServer'
+        'msRTCSIP-ConferenceDirectories'       = 'top, container, msRTCSIP-ConferenceDirectories'
+        'msRTCSIP-ConferenceDirectory'         = 'top, container, msRTCSIP-ConferenceDirectory'
+        'msRTCSIP-Domain'                      = 'top, container, msRTCSIP-Domain'
+        'msRTCSIP-EdgeProxy'                   = 'top, container, msRTCSIP-EdgeProxy'
+        'msRTCSIP-GlobalContainer'             = 'top, container, msRTCSIP-GlobalContainer'
+        'msRTCSIP-GlobalTopologySetting'       = 'top, container, msRTCSIP-GlobalTopologySetting'
+        'msRTCSIP-GlobalTopologySettings'      = 'top, container, msRTCSIP-GlobalTopologySettings'
+        'msRTCSIP-GlobalUserPolicy'            = 'top, container, msRTCSIP-GlobalUserPolicy'
+        'msRTCSIP-LocalNormalization'          = 'top, container, msRTCSIP-LocalNormalization'
+        'msRTCSIP-LocalNormalizations'         = 'top, container, msRTCSIP-LocalNormalizations'
+        'msRTCSIP-LocationContactMapping'      = 'top, container, msRTCSIP-LocationContactMapping'
+        'msRTCSIP-LocationContactMappings'     = 'top, container, msRTCSIP-LocationContactMappings'
+        'msRTCSIP-LocationProfile'             = 'top, container, msRTCSIP-LocationProfile'
+        'msRTCSIP-LocationProfiles'            = 'top, container, msRTCSIP-LocationProfiles'
+        'msRTCSIP-MCUFactories'                = 'top, container, msRTCSIP-MCUFactories'
+        'msRTCSIP-MCUFactory'                  = 'top, container, msRTCSIP-MCUFactory'
+        'msRTCSIP-MonitoringServer'            = 'top, container, msRTCSIP-MonitoringServer'
+        'msRTCSIP-PhoneRoute'                  = 'top, container, msRTCSIP-PhoneRoute'
+        'msRTCSIP-PhoneRoutes'                 = 'top, container, msRTCSIP-PhoneRoutes'
+        'msRTCSIP-Policies'                    = 'top, container, msRTCSIP-Policies'
+        'msRTCSIP-Pool'                        = 'top, container, msRTCSIP-Pool'
+        'msRTCSIP-Pools'                       = 'top, container, msRTCSIP-Pools'
+        'msRTCSIP-RouteUsage'                  = 'top, container, msRTCSIP-RouteUsage'
+        'msRTCSIP-RouteUsages'                 = 'top, container, msRTCSIP-RouteUsages'
+        'msRTCSIP-TrustedMCU'                  = 'top, container, msRTCSIP-TrustedMCU'
+        'msRTCSIP-TrustedMCUs'                 = 'top, container, msRTCSIP-TrustedMCUs'
+        'msRTCSIP-TrustedProxies'              = 'top, container, msRTCSIP-TrustedProxies'
+        'msRTCSIP-TrustedServer'               = 'top, container, msRTCSIP-TrustedServer'
+        'msRTCSIP-TrustedService'              = 'top, container, msRTCSIP-TrustedService'
+        'msRTCSIP-TrustedServices'             = 'top, container, msRTCSIP-TrustedServices'
+        'msRTCSIP-TrustedWebComponentsServer'  = 'top, container, msRTCSIP-TrustedWebComponentsServer'
+        'msRTCSIP-TrustedWebComponentsServers' = 'top, container, msRTCSIP-TrustedWebComponentsServers'
+        'msWMI-Som'                            = 'top, msWMI-Som'
+        'nTFRSReplicaSet'                      = 'top, nTFRSReplicaSet'
+        'packageRegistration'                  = 'top, packageRegistration'
+        'msDS-GroupManagedServiceAccount'      = 'top, person, organizationalPerson, user, computer, msDS-GroupManagedServiceAccount'
+        'pKIEnrollmentService'                 = 'top, pKIEnrollmentService'
+        'nTFRSSettings'                        = 'top, applicationSettings, nTFRSSettings'
+        'rpcServer'                            = 'top, leaf, connectionPoint, rpcEntry, rpcServer'
+        'rpcServerElement'                     = 'top, leaf, connectionPoint, rpcEntry, rpcServerElement'
+        'serviceConnectionPoint'               = 'top, leaf, connectionPoint, serviceConnectionPoint'
+        'msRTCSIP-ApplicationServerService'    = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-ApplicationServerService'
+        'msRTCSIP-MCUFactoryService'           = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-MCUFactoryService'
+        'msRTCSIP-PoolService'                 = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-PoolService'
+        'msRTCSIP-Service'                     = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-Service'
+        'msRTCSIP-WebComponentsService'        = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-WebComponentsService'
+        'pKICertificateTemplate'               = 'top, pKICertificateTemplate'
+        'certificationAuthority'               = 'top, certificationAuthority'
+        'msPKI-Enterprise-Oid'                 = 'top, msPKI-Enterprise-Oid'
+    }
+
+    if ($null -eq $AdObject) {
+        Write-Error 'AdObject is null'
+        return
+    }
+
+    $outputLines = New-Object System.Collections.Generic.List[string]
+    $outputLines.Add('--------------------')
+
+    foreach ($property in $AdObject.PSObject.Properties) {
+        $name = $property.Name
+        $value = $property.Value
+
+        # Skip properties with empty values and unwanted properties
+        if ($null -eq $value -or ($value -is [string] -and [string]::IsNullOrWhiteSpace($value)) -or $ignoredValues -contains $name) {
+            continue
         }
 
-        function Process-AdObject {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [Microsoft.ActiveDirectory.Management.ADObject]$AdObject,
+        # Cache type checks
+        $isDateTime = $value -is [datetime]
+        $isByteArray = $value -is [byte[]]
+        $isGuid = $value -is [guid]
+        $isCollection = $value -is [Microsoft.ActiveDirectory.Management.ADPropertyValueCollection]
 
-                [Parameter(Mandatory = $true)]
-                [System.IO.StreamWriter]$StreamWriter
-            )
-
-            # Define ignored properties
-            $ignoredValues = @(
-                'CanonicalName', 'PropertyNames', 'AddedProperties', 'RemovedProperties',
-                'ModifiedProperties', 'PropertyCount', 'repsTo', 'ProtectedFromAccidentalDeletion',
-                'sDRightsEffective', 'modifyTimeStamp', 'Modified', 'createTimeStamp',
-                'Created', 'userCertificate'
-            )
-
-            # Map object classes
-            $objectClassMapping = @{
-                'applicationSettings'                  = 'top, applicationSettings, nTFRSSettings'
-                'builtinDomain'                        = 'top, builtinDomain'
-                'classStore'                           = 'top, classStore'
-                'container'                            = 'top, container'
-                'groupPolicyContainer'                 = 'top, container, groupPolicyContainer'
-                'msImaging-PSPs'                       = 'top, container, msImaging-PSPs'
-                'rpcContainer'                         = 'top, container, rpcContainer'
-                'dfsConfiguration'                     = 'top, dfsConfiguration'
-                'dnsNode'                              = 'top, dnsNode'
-                'dnsZone'                              = 'top, dnsZone'
-                'domainDNS'                            = 'top, domain, domainDNS'
-                'fileLinkTracking'                     = 'top, fileLinkTracking'
-                'linkTrackObjectMoveTable'             = 'top, fileLinkTracking, linkTrackObjectMoveTable'
-                'linkTrackVolumeTable'                 = 'top, fileLinkTracking, linkTrackVolumeTable'
-                'foreignSecurityPrincipal'             = 'top, foreignSecurityPrincipal'
-                'group'                                = 'top, group'
-                'infrastructureUpdate'                 = 'top, infrastructureUpdate'
-                'ipsecFilter'                          = 'top, ipsecBase, ipsecFilter'
-                'ipsecISAKMPPolicy'                    = 'top, ipsecBase, ipsecISAKMPPolicy'
-                'ipsecNegotiationPolicy'               = 'top, ipsecBase, ipsecNegotiationPolicy'
-                'ipsecNFA'                             = 'top, ipsecBase, ipsecNFA'
-                'ipsecPolicy'                          = 'top, ipsecBase, ipsecPolicy'
-                'domainPolicy'                         = 'top, leaf, domainPolicy'
-                'secret'                               = 'top, leaf, secret'
-                'trustedDomain'                        = 'top, leaf, trustedDomain'
-                'lostAndFound'                         = 'top, lostAndFound'
-                'msDFSR-Content'                       = 'top, msDFSR-Content'
-                'msDFSR-ContentSet'                    = 'top, msDFSR-ContentSet'
-                'msDFSR-GlobalSettings'                = 'top, msDFSR-GlobalSettings'
-                'msDFSR-LocalSettings'                 = 'top, msDFSR-LocalSettings'
-                'msDFSR-Member'                        = 'top, msDFSR-Member'
-                'msDFSR-ReplicationGroup'              = 'top, msDFSR-ReplicationGroup'
-                'msDFSR-Subscriber'                    = 'top, msDFSR-Subscriber'
-                'msDFSR-Subscription'                  = 'top, msDFSR-Subscription'
-                'msDFSR-Topology'                      = 'top, msDFSR-Topology'
-                'msDS-PasswordSettingsContainer'       = 'top, msDS-PasswordSettingsContainer'
-                'msDS-QuotaContainer'                  = 'top, msDS-QuotaContainer'
-                'msTPM-InformationObjectsContainer'    = 'top, msTPM-InformationObjectsContainer'
-                'organizationalUnit'                   = 'top, organizationalUnit'
-                'contact'                              = 'top, person, organizationalPerson, contact'
-                'user'                                 = 'top, person, organizationalPerson, user'
-                'computer'                             = 'top, person, organizationalPerson, user, computer'
-                'rIDManager'                           = 'top, rIDManager'
-                'rIDSet'                               = 'top, rIDSet'
-                'samServer'                            = 'top, securityObject, samServer'
-                'msExchSystemObjectsContainer'         = 'top, container, msExchSystemObjectsContainer'
-                'msRTCSIP-ApplicationContacts'         = 'top, container, msRTCSIP-ApplicationContacts'
-                'msRTCSIP-ArchivingServer'             = 'top, container, msRTCSIP-ArchivingServer'
-                'msRTCSIP-ConferenceDirectories'       = 'top, container, msRTCSIP-ConferenceDirectories'
-                'msRTCSIP-ConferenceDirectory'         = 'top, container, msRTCSIP-ConferenceDirectory'
-                'msRTCSIP-Domain'                      = 'top, container, msRTCSIP-Domain'
-                'msRTCSIP-EdgeProxy'                   = 'top, container, msRTCSIP-EdgeProxy'
-                'msRTCSIP-GlobalContainer'             = 'top, container, msRTCSIP-GlobalContainer'
-                'msRTCSIP-GlobalTopologySetting'       = 'top, container, msRTCSIP-GlobalTopologySetting'
-                'msRTCSIP-GlobalTopologySettings'      = 'top, container, msRTCSIP-GlobalTopologySettings'
-                'msRTCSIP-GlobalUserPolicy'            = 'top, container, msRTCSIP-GlobalUserPolicy'
-                'msRTCSIP-LocalNormalization'          = 'top, container, msRTCSIP-LocalNormalization'
-                'msRTCSIP-LocalNormalizations'         = 'top, container, msRTCSIP-LocalNormalizations'
-                'msRTCSIP-LocationContactMapping'      = 'top, container, msRTCSIP-LocationContactMapping'
-                'msRTCSIP-LocationContactMappings'     = 'top, container, msRTCSIP-LocationContactMappings'
-                'msRTCSIP-LocationProfile'             = 'top, container, msRTCSIP-LocationProfile'
-                'msRTCSIP-LocationProfiles'            = 'top, container, msRTCSIP-LocationProfiles'
-                'msRTCSIP-MCUFactories'                = 'top, container, msRTCSIP-MCUFactories'
-                'msRTCSIP-MCUFactory'                  = 'top, container, msRTCSIP-MCUFactory'
-                'msRTCSIP-MonitoringServer'            = 'top, container, msRTCSIP-MonitoringServer'
-                'msRTCSIP-PhoneRoute'                  = 'top, container, msRTCSIP-PhoneRoute'
-                'msRTCSIP-PhoneRoutes'                 = 'top, container, msRTCSIP-PhoneRoutes'
-                'msRTCSIP-Policies'                    = 'top, container, msRTCSIP-Policies'
-                'msRTCSIP-Pool'                        = 'top, container, msRTCSIP-Pool'
-                'msRTCSIP-Pools'                       = 'top, container, msRTCSIP-Pools'
-                'msRTCSIP-RouteUsage'                  = 'top, container, msRTCSIP-RouteUsage'
-                'msRTCSIP-RouteUsages'                 = 'top, container, msRTCSIP-RouteUsages'
-                'msRTCSIP-TrustedMCU'                  = 'top, container, msRTCSIP-TrustedMCU'
-                'msRTCSIP-TrustedMCUs'                 = 'top, container, msRTCSIP-TrustedMCUs'
-                'msRTCSIP-TrustedProxies'              = 'top, container, msRTCSIP-TrustedProxies'
-                'msRTCSIP-TrustedServer'               = 'top, container, msRTCSIP-TrustedServer'
-                'msRTCSIP-TrustedService'              = 'top, container, msRTCSIP-TrustedService'
-                'msRTCSIP-TrustedServices'             = 'top, container, msRTCSIP-TrustedServices'
-                'msRTCSIP-TrustedWebComponentsServer'  = 'top, container, msRTCSIP-TrustedWebComponentsServer'
-                'msRTCSIP-TrustedWebComponentsServers' = 'top, container, msRTCSIP-TrustedWebComponentsServers'
-                'msWMI-Som'                            = 'top, msWMI-Som'
-                'nTFRSReplicaSet'                      = 'top, nTFRSReplicaSet'
-                'packageRegistration'                  = 'top, packageRegistration'
-                'msDS-GroupManagedServiceAccount'      = 'top, person, organizationalPerson, user, computer, msDS-GroupManagedServiceAccount'
-                'pKIEnrollmentService'                 = 'top, pKIEnrollmentService'
-                'nTFRSSettings'                        = 'top, applicationSettings, nTFRSSettings'
-                'rpcServer'                            = 'top, leaf, connectionPoint, rpcEntry, rpcServer'
-                'rpcServerElement'                     = 'top, leaf, connectionPoint, rpcEntry, rpcServerElement'
-                'serviceConnectionPoint'               = 'top, leaf, connectionPoint, serviceConnectionPoint'
-                'msRTCSIP-ApplicationServerService'    = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-ApplicationServerService'
-                'msRTCSIP-MCUFactoryService'           = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-MCUFactoryService'
-                'msRTCSIP-PoolService'                 = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-PoolService'
-                'msRTCSIP-Service'                     = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-Service'
-                'msRTCSIP-WebComponentsService'        = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-WebComponentsService'
-                'pKICertificateTemplate'               = 'top, pKICertificateTemplate'
-                'certificationAuthority'               = 'top, certificationAuthority'
-                'msPKI-Enterprise-Oid'                 = 'top, msPKI-Enterprise-Oid'
-            }
-
-            if ($null -eq $AdObject) {
-                Write-Error 'AdObject is null'
-                return
-            }
-
-            $outputLines = New-Object System.Collections.Generic.List[string]
-            $outputLines.Add('--------------------')
-
-            foreach ($property in $AdObject.PSObject.Properties) {
-                $name = $property.Name
-                $value = $property.Value
-
-                # Skip properties with empty values and unwanted properties
-                if ($null -eq $value -or ($value -is [string] -and [string]::IsNullOrWhiteSpace($value)) -or $ignoredValues -contains $name) {
-                    continue
-                }
-
-                # Cache type checks
-                $isDateTime = $value -is [datetime]
-                $isByteArray = $value -is [byte[]]
-                $isGuid = $value -is [guid]
-                $isCollection = $value -is [Microsoft.ActiveDirectory.Management.ADPropertyValueCollection]
-
-                switch ($name) {
-                    'nTSecurityDescriptor' {
-                        if ($null -ne $value) {
-                            $binaryForm = $value.GetSecurityDescriptorBinaryForm()
-                            if ($binaryForm.Length -gt 0) {
-                                $base64Value = [System.Convert]::ToBase64String($binaryForm)
-                                $outputLines.Add("$name`: $base64Value")
-                            }
-                        }
-                        break
-                    }
-                    'objectClass' {
-                        if ($objectClassMapping.ContainsKey($value)) {
-                            $formattedObjectClass = $objectClassMapping[$value]
-                        }
-                        else {
-                            $formattedObjectClass = ($value -join ', ')
-                        }
-                        $outputLines.Add("$name`: $formattedObjectClass")
-                        break
-                    }
-                    default {
-                        if ($isDateTime) {
-                            # Format date/time attributes in LDAP time format
-                            $formattedValue = '{0:yyyyMMddHHmmss.0Z}' -f $value.ToUniversalTime()
-                            $outputLines.Add("$name`: $formattedValue")
-                        }
-                        elseif ($isByteArray) {
-                            # Base64 encode byte arrays
-                            if ($value.Length -gt 0) {
-                                $base64Value = [System.Convert]::ToBase64String($value)
-                                $outputLines.Add("$name`: $base64Value")
-                            }
-                        }
-                        elseif ($isGuid) {
-                            $outputLines.Add("$name`: $value")
-                        }
-                        elseif ($isCollection) {
-                            switch ($name) {
-                                'dSCorePropagationData' {
-                                    # Efficiently find the latest date
-                                    $latestDate = $null
-                                    foreach ($date in $value) {
-                                        if ($date -is [datetime]) {
-                                            if ($null -eq $latestDate -or $date -gt $latestDate) {
-                                                $latestDate = $date
-                                            }
-                                        }
-                                    }
-                                    if ($null -ne $latestDate) {
-                                        $formattedDate = '{0:yyyyMMddHHmmss.0Z}' -f $latestDate.ToUniversalTime()
-                                        $outputLines.Add("$name`: $formattedDate")
-                                    }
-                                    break
-                                }
-                                'cACertificate' {
-                                    if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
-                                        $base64Value = [System.Convert]::ToBase64String($value[0])
-                                        $outputLines.Add("$name`: $base64Value")
-                                    }
-                                    break
-                                }
-                                'userCertificate' {
-                                    if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
-                                        $base64Value = [System.Convert]::ToBase64String($value[0])
-                                        $outputLines.Add("$name`: $base64Value")
-                                    }
-                                    break
-                                }
-                                'authorityRevocationList' {
-                                    $outputLines.Add("$name`: $null")
-                                    break
-                                }
-                                default {
-                                    $joinedValues = ($value | ForEach-Object { $_.ToString() }) -join ', '
-                                    $outputLines.Add("$name`: $joinedValues")
-                                    break
-                                }
-                            }
-                        }
-                        else {
-                            # General handling for other types
-                            $outputLines.Add("$name`: $value")
-                        }
-                        break
+        switch ($name) {
+            'nTSecurityDescriptor' {
+                if ($null -ne $value) {
+                    $binaryForm = $value.GetSecurityDescriptorBinaryForm()
+                    if ($binaryForm.Length -gt 0) {
+                        $base64Value = [System.Convert]::ToBase64String($binaryForm)
+                        $outputLines.Add("$name`: $base64Value")
                     }
                 }
+                break
             }
-
-            # Write the formatted content to the file using StreamWriter
-            foreach ($line in $outputLines) {
-                $StreamWriter.WriteLine($line)
-            }
-        }
-
-        function Perform-ADQuery {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [hashtable]$SearchParams,
-
-                [Parameter(Mandatory = $true)]
-                [System.IO.StreamWriter]$StreamWriter,
-
-                [Parameter(Mandatory = $true)]
-                [ref]$Count,
-
-                [Parameter(Mandatory = $false)]
-                [int]$PrintingThreshold = 1000
-            )
-
-            $SearchParams['ResultSetSize'] = 100000
-    
-            Get-ADObject @SearchParams | ForEach-Object {
-                Process-AdObject -AdObject $_ -StreamWriter $StreamWriter
-                $Count.Value++
-                if ($Count.Value % $PrintingThreshold -eq 0) {
-                    Write-Output "      [**] Queried $($Count.Value) objects so far..."
-                }
-            }
-    
-            $StreamWriter.Flush()
-        }
-
-        function Get-TopLevelContainers {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [hashtable]$Params
-            )
-
-            try {
-                $topLevelParams = $Params.Clone()
-                $topLevelParams['SearchScope'] = 'OneLevel'
-                $TopLevelContainers = Get-ADObject @topLevelParams 
-                return $TopLevelContainers
-            }
-            catch {
-                Write-Error "Failed to retrieve top-level containers: $_"
-                return $null
-            }
-        }
-
-        function Initialize-StateFile {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [string]$Path,
-
-                [Parameter(Mandatory = $true)]
-                [string]$Output,
-
-                [Parameter(Mandatory = $false)]
-                [string]$Server,
-
-                [Parameter(Mandatory = $false)]
-                [string]$LdapFilter,
-
-                [Parameter(Mandatory = $false)]
-                [string]$SearchBase,
-
-                [Parameter(Mandatory = $false)]
-                [bool]$SplitSearch = $false,
-
-                [Parameter(Mandatory = $false)]
-                [bool]$LetterSplitSearch = $false
-            )
-
-            # Determine execution mode
-            $mode = 'Standard'
-            if ($SplitSearch -and $LetterSplitSearch) {
-                $mode = 'SplitSearch+LetterSplitSearch'
-            }
-            elseif ($SplitSearch) {
-                $mode = 'SplitSearch'
-            }
-            elseif ($LetterSplitSearch) {
-                $mode = 'LetterSplitSearch'
-            }
-
-            $state = @{
-                version             = '1.0'
-                toolMethod          = 'ShadowHound-ADM'
-                timestamp           = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-                outputFile          = $Output
-                executionMode       = $mode
-                ldapFilter          = if ($LdapFilter) { $LdapFilter } else { '(objectGuid=*)' }
-                completedContainers = @()
-                completedLetters    = @()
-                failedLetters       = @{}
-                objectCount         = 0
-            }
-
-            if ($Server) { $state.server = $Server }
-            if ($SearchBase) { $state.searchBase = $SearchBase }
-
-            return $state
-        }
-
-        function Test-StateFileExists {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [string]$Path
-            )
-
-            return (Test-Path -Path $Path -PathType Leaf)
-        }
-
-        function Read-StateFile {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [string]$Path
-            )
-
-            try {
-                $json = Get-Content -Path $Path -Raw -ErrorAction Stop
-                $psobject = $json | ConvertFrom-Json -ErrorAction Stop
-        
-                $state = @{}
-                $psobject.PSObject.Properties | ForEach-Object {
-                    $name = $_.Name
-                    $value = $_.Value
-            
-                    if ($value -is [PSCustomObject]) {
-                        $nested = @{}
-                        $value.PSObject.Properties | ForEach-Object {
-                            $nested[$_.Name] = $_.Value
-                        }
-                        $state[$name] = $nested
-                    }
-                    else {
-                        $state[$name] = $value
-                    }
-                }
-        
-                return $state
-            }
-            catch {
-                return $null
-            }
-        }
-
-        function Write-StateFile {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [hashtable]$State,
-
-                [Parameter(Mandatory = $true)]
-                [string]$Path
-            )
-
-            try {
-                $State.timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-                $json = $State | ConvertTo-Json -Depth 10
-        
-                try {
-                    $json = [regex]::Replace($json, '(?ms)("completedLetters"\s*:\s*\[)(.*?)(\])', {
-                            param($match)
-                            $prefix = $match.Groups[1].Value
-                            $content = $match.Groups[2].Value
-                            $suffix = $match.Groups[3].Value
-                            $compacted = $content -replace '\s+', ''
-                            "$prefix$compacted$suffix"
-                        })
-                }
-                catch {
-                    # Regex failed, use formatted JSON as-is
-                }
-
-                $json | Set-Content -Path $Path -Force -ErrorAction Stop
-            }
-            catch {
-                Write-Error "[-] Failed to write state file: $_"
-            }
-        }
-
-        function Remove-StateFile {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                [string]$Path
-            )
-
-            if (Test-Path -Path $Path) {
-                try {
-                    Remove-Item -Path $Path -Force -ErrorAction Stop
-                }
-                catch {
-                    Write-Error "[-] Failed to remove state file: $_"
-                }
-            }
-        }
-
-        function Show-StatePrompt {
-            [CmdletBinding()]
-            param (
-                [Parameter(Mandatory = $true)]
-                $State,
-
-                [Parameter(Mandatory = $true)]
-                [string]$Path,
-
-                [Parameter(Mandatory = $false)]
-                [switch]$NonInteractive
-            )
-
-            [Console]::WriteLine('')
-            [Console]::WriteLine('[*] Found existing state file: ' + $Path)
-            [Console]::WriteLine('[*] Last checkpoint:')
-    
-            $containers = $State['completedContainers']
-            if ($containers -and $containers.Count -gt 0) {
-                [Console]::WriteLine("    - Completed containers: $($containers.Count)")
-            }
-    
-            $currentContainer = $State['currentContainer']
-            if ($currentContainer) {
-                [Console]::WriteLine("    - Current container: $currentContainer")
-            }
-    
-            $letters = $State['completedLetters']
-            if ($letters -and $letters.Count -gt 0) {
-                $letterList = $letters -join ', '
-                if ($currentContainer) {
-                    [Console]::WriteLine("    - Completed letters (in current container): $letterList")
+            'objectClass' {
+                if ($objectClassMapping.ContainsKey($value)) {
+                    $formattedObjectClass = $objectClassMapping[$value]
                 }
                 else {
-                    [Console]::WriteLine("    - Completed letters: $letterList")
+                    $formattedObjectClass = ($value -join ', ')
                 }
+                $outputLines.Add("$name`: $formattedObjectClass")
+                break
             }
-            elseif ($currentContainer) {
-                [Console]::WriteLine('    - Completed letters (in current container): (none yet)')
-            }
-            else {
-                [Console]::WriteLine('    - Completed letters: (none yet)')
-            }
-    
-            $objCount = $State['objectCount']
-            if ($objCount -and $objCount -gt 0) {
-                [Console]::WriteLine("    - Objects enumerated: $objCount")
-            }
-    
-            $failedLetters = $State['failedLetters']
-            if ($failedLetters -and $failedLetters.Count -gt 0) {
-                [Console]::WriteLine('')
-                [Console]::WriteLine('[!] Failed letters detected (will be retried on resume):')
-                foreach ($container in $failedLetters.Keys) {
-                    $letters = $failedLetters[$container] -join ', '
-                    [Console]::WriteLine("    Container: $container")
-                    [Console]::WriteLine("    Letters: $letters")
+            default {
+                if ($isDateTime) {
+                    # Format date/time attributes in LDAP time format
+                    $formattedValue = '{0:yyyyMMddHHmmss.0Z}' -f $value.ToUniversalTime()
+                    $outputLines.Add("$name`: $formattedValue")
                 }
-            }
-    
-            $timestamp = $State['timestamp']
-            if ($timestamp) {
-                [Console]::WriteLine("    - Timestamp: $timestamp")
-            }
-    
-            [Console]::WriteLine('')
-            [Console]::WriteLine('[!] Note: Resuming will append to existing output file')
-            [Console]::WriteLine('')
-
-            if ($NonInteractive) {
-                [Console]::WriteLine('[*] Non-interactive mode: Auto-resuming...')
-                return 'Y'
-            }
-
-            while ($true) {
-                $choice = Read-Host '[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel'
-                $choice = $choice.Trim().ToUpper()
-        
-                if ($choice -eq 'Y' -or $choice -eq 'YES') {
-                    [Console]::WriteLine('[+] Resuming from checkpoint...')
-                    return 'Y'
+                elseif ($isByteArray) {
+                    # Base64 encode byte arrays
+                    if ($value.Length -gt 0) {
+                        $base64Value = [System.Convert]::ToBase64String($value)
+                        $outputLines.Add("$name`: $base64Value")
+                    }
                 }
-                elseif ($choice -eq 'N' -or $choice -eq 'NO') {
-                    [Console]::WriteLine('[+] Starting fresh enumeration...')
-                    return 'N'
+                elseif ($isGuid) {
+                    $outputLines.Add("$name`: $value")
                 }
-                elseif ($choice -eq 'C' -or $choice -eq 'CANCEL') {
-                    [Console]::WriteLine('[-] Cancelled by user')
-                    return 'C'
+                elseif ($isCollection) {
+                    switch ($name) {
+                        'dSCorePropagationData' {
+                            # Efficiently find the latest date
+                            $latestDate = $null
+                            foreach ($date in $value) {
+                                if ($date -is [datetime]) {
+                                    if ($null -eq $latestDate -or $date -gt $latestDate) {
+                                        $latestDate = $date
+                                    }
+                                }
+                            }
+                            if ($null -ne $latestDate) {
+                                $formattedDate = '{0:yyyyMMddHHmmss.0Z}' -f $latestDate.ToUniversalTime()
+                                $outputLines.Add("$name`: $formattedDate")
+                            }
+                            break
+                        }
+                        'cACertificate' {
+                            if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
+                                $base64Value = [System.Convert]::ToBase64String($value[0])
+                                $outputLines.Add("$name`: $base64Value")
+                            }
+                            break
+                        }
+                        'userCertificate' {
+                            if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
+                                $base64Value = [System.Convert]::ToBase64String($value[0])
+                                $outputLines.Add("$name`: $base64Value")
+                            }
+                            break
+                        }
+                        'authorityRevocationList' {
+                            $outputLines.Add("$name`: $null")
+                            break
+                        }
+                        default {
+                            $joinedValues = ($value | ForEach-Object { $_.ToString() }) -join ', '
+                            $outputLines.Add("$name`: $joinedValues")
+                            break
+                        }
+                    }
                 }
                 else {
-                    [Console]::WriteLine('[!] Invalid input. Please enter Y, N, or C.')
+                    # General handling for other types
+                    $outputLines.Add("$name`: $value")
                 }
+                break
             }
         }
     }
+
+    # Write the formatted content to the file using StreamWriter
+    foreach ($line in $outputLines) {
+        $StreamWriter.WriteLine($line)
+    }
+}
+
+function Perform-ADQuery {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [hashtable]$SearchParams,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.StreamWriter]$StreamWriter,
+
+        [Parameter(Mandatory = $true)]
+        [ref]$Count,
+
+        [Parameter(Mandatory = $false)]
+        [int]$PrintingThreshold = 1000
+    )
+
+    $SearchParams['ResultSetSize'] = 100000
+
+    Get-ADObject @SearchParams | ForEach-Object {
+        Process-AdObject -AdObject $_ -StreamWriter $StreamWriter
+        $Count.Value++
+        if ($Count.Value % $PrintingThreshold -eq 0) {
+            Write-Output "      [**] Queried $($Count.Value) objects so far..."
+        }
+    }
+    
+    $StreamWriter.Flush()
+}
+
+function Get-TopLevelContainers {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Params
+    )
+
+    try {
+        $topLevelParams = $Params.Clone()
+        $topLevelParams['SearchScope'] = 'OneLevel'
+        $TopLevelContainers = Get-ADObject @topLevelParams 
+        return $TopLevelContainers
+    }
+    catch {
+        Write-Error "Failed to retrieve top-level containers: $_"
+        return $null
+    }
+}
+
+function Initialize-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Output,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Server,
+
+        [Parameter(Mandatory = $false)]
+        [string]$LdapFilter,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SearchBase,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$SplitSearch = $false,
+
+        [Parameter(Mandatory = $false)]
+        [bool]$LetterSplitSearch = $false
+    )
+
+    # Determine execution mode
+    $mode = 'Standard'
+    if ($SplitSearch -and $LetterSplitSearch) {
+        $mode = 'SplitSearch+LetterSplitSearch'
+    }
+    elseif ($SplitSearch) {
+        $mode = 'SplitSearch'
+    }
+    elseif ($LetterSplitSearch) {
+        $mode = 'LetterSplitSearch'
+    }
+
+    $state = @{
+        version             = '1.0'
+        toolMethod          = 'ShadowHound-ADM'
+        timestamp           = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        outputFile          = $Output
+        executionMode       = $mode
+        ldapFilter          = if ($LdapFilter) { $LdapFilter } else { '(objectGuid=*)' }
+        completedContainers = @()
+        completedLetters    = @()
+        failedLetters       = @{}
+        objectCount         = 0
+    }
+
+    if ($Server) { $state.server = $Server }
+    if ($SearchBase) { $state.searchBase = $SearchBase }
+
+    return $state
+}
+
+function Test-StateFileExists {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return (Test-Path -Path $Path -PathType Leaf)
+}
+
+function Read-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    try {
+        $json = Get-Content -Path $Path -Raw -ErrorAction Stop
+        $psobject = $json | ConvertFrom-Json -ErrorAction Stop
+        
+        $state = @{}
+        $psobject.PSObject.Properties | ForEach-Object {
+            $name = $_.Name
+            $value = $_.Value
+            
+            if ($value -is [PSCustomObject]) {
+                $nested = @{}
+                $value.PSObject.Properties | ForEach-Object {
+                    $nested[$_.Name] = $_.Value
+                }
+                $state[$name] = $nested
+            }
+            else {
+                $state[$name] = $value
+            }
+        }
+        
+        return $state
+    }
+    catch {
+        return $null
+    }
+}
+
+function Write-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [hashtable]$State,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    try {
+        $State.timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $json = $State | ConvertTo-Json -Depth 10
+        
+        # Custom compaction for letters only
+        try {
+            # specific regex to compact completedLetters and failedLetters values only
+            $json = [regex]::Replace($json, '(?ms)"(completedLetters|failedLetters)":\s*\[(.*?)\]', {
+                    param($match)
+                    $key = $match.Groups[1].Value
+                    $content = $match.Groups[2].Value
+                    # Compact the array content
+                    $compacted = $content -replace '\s+', ''
+                    "`"$key`": [$compacted]"
+                })
+        }
+        catch {
+            # Regex failed, use formatted JSON
+        }
+
+        
+        $json | Set-Content -Path $Path -Force -ErrorAction Stop
+    }
+    catch {
+        Write-Error "[-] Failed to write state file: $_"
+    }
+}
+
+function Remove-StateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (Test-Path -Path $Path) {
+        try {
+            Remove-Item -Path $Path -Force -ErrorAction Stop
+        }
+        catch {
+            Write-Error "[-] Failed to remove state file: $_"
+        }
+    }
+}
+
+function Show-StatePrompt {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        $State,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    [Console]::WriteLine('')
+    [Console]::WriteLine('[*] Found existing state file: ' + $Path)
+    [Console]::WriteLine('[*] Last checkpoint:')
+    
+    $containers = $State['completedContainers']
+    if ($containers -and $containers.Count -gt 0) {
+        [Console]::WriteLine("    - Completed containers: $($containers.Count)")
+    }
+    
+    $currentContainer = $State['currentContainer']
+    if ($currentContainer) {
+        [Console]::WriteLine("    - Current container: $currentContainer")
+    }
+    
+    $letters = $State['completedLetters']
+    if ($letters -and $letters.Count -gt 0) {
+        $letterList = $letters -join ', '
+        if ($currentContainer) {
+            [Console]::WriteLine("    - Completed letters (in current container): $letterList")
+        }
+        else {
+            [Console]::WriteLine("    - Completed letters: $letterList")
+        }
+    }
+    elseif ($currentContainer) {
+        [Console]::WriteLine('    - Completed letters (in current container): (none yet)')
+    }
+    else {
+        [Console]::WriteLine('    - Completed letters: (none yet)')
+    }
+    
+    $objCount = $State['objectCount']
+    if ($objCount -and $objCount -gt 0) {
+        [Console]::WriteLine("    - Objects enumerated: $objCount")
+    }
+    
+    $failedLetters = $State['failedLetters']
+    if ($failedLetters -and $failedLetters.Count -gt 0) {
+        [Console]::WriteLine('')
+        [Console]::WriteLine('[!] Failed letters detected (will be retried on resume):')
+        foreach ($container in $failedLetters.Keys) {
+            $letters = $failedLetters[$container] -join ', '
+            [Console]::WriteLine("    Container: $container")
+            [Console]::WriteLine("    Letters: $letters")
+        }
+    }
+    
+    $timestamp = $State['timestamp']
+    if ($timestamp) {
+        [Console]::WriteLine("    - Timestamp: $timestamp")
+    }
+    
+    [Console]::WriteLine('')
+    [Console]::WriteLine('[!] Note: Resuming will append to existing output file')
+    [Console]::WriteLine('')
+
+    while ($true) {
+        $choice = Read-Host '[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel'
+        $choice = $choice.Trim().ToUpper()
+        
+        if ($choice -eq 'Y' -or $choice -eq 'YES') {
+            [Console]::WriteLine('[+] Resuming from checkpoint...')
+            return 'Y'
+        }
+        elseif ($choice -eq 'N' -or $choice -eq 'NO') {
+            [Console]::WriteLine('[+] Starting fresh enumeration...')
+            return 'N'
+        }
+        elseif ($choice -eq 'C' -or $choice -eq 'CANCEL') {
+            [Console]::WriteLine('[-] Cancelled by user')
+            return 'C'
+        }
+        else {
+            [Console]::WriteLine('[!] Invalid input. Please enter Y, N, or C.')
+        }
+    }
+}

--- a/ShadowHound-ADM.ps1
+++ b/ShadowHound-ADM.ps1
@@ -49,7 +49,10 @@ function ShadowHound-ADM {
         [switch]$KeepStateFile,
 
         [Parameter(Mandatory = $false, HelpMessage = 'Display help information.')]
-        [switch]$Help
+        [switch]$Help,
+
+        [Parameter(Mandatory = $false, HelpMessage = 'Disable interactive prompts for automation and C2.')]
+        [switch]$NonInteractive
     )
 
     if ($Help) {
@@ -64,6 +67,12 @@ function ShadowHound-ADM {
 
     if (-not $OutputFilePath) {
         Write-Error '[!] -OutputFilePath is required.'
+        return
+    }
+
+    $parentDir = Split-Path -Path $OutputFilePath -Parent
+    if ($parentDir -and -not (Test-Path -Path $parentDir)) {
+        Write-Error "[!] The directory for OutputFilePath does not exist: $parentDir"
         return
     }
 
@@ -82,6 +91,10 @@ function ShadowHound-ADM {
         return
     }
 
+    if ($StartFromLetter -and -not $LetterSplitSearch) {
+        Write-Error '[!] -StartFromLetter requires -LetterSplitSearch to be enabled.'
+        return
+    }
 
     Print-Logo
     Write-Output '[+] Executing with the following parameters:'
@@ -129,256 +142,538 @@ function ShadowHound-ADM {
                 Write-Output '[!] WARNING: State file exists but is corrupted or unreadable.'
                 Write-Output "[!] Path: $statePath"
                 Write-Output ''
-                while ($true) {
-                    $corruptChoice = Read-Host '[?] Delete corrupted state file and start fresh? [Y]es, [C]ancel'
-                    $corruptChoice = $corruptChoice.Trim().ToUpper()
-                    if ($corruptChoice -eq 'Y' -or $corruptChoice -eq 'YES') {
-                        Write-Output '[+] Deleting corrupted state file and starting fresh...'
-                        Remove-StateFile -Path $statePath
-                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-                        break
-                    } elseif ($corruptChoice -eq 'C' -or $corruptChoice -eq 'CANCEL') {
-                        Write-Output '[-] Cancelled by user'
-                        return
-                    } else {
-                        Write-Output '[!] Invalid input. Please enter Y or C.'
-                    }
+                if ($NonInteractive) {
+                    Write-Output '[*] Non-interactive mode: Deleting corrupted state file and starting fresh...'
+                    Remove-StateFile -Path $statePath
+                    $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
                 }
-            } elseif ($existingState['toolMethod'] -and $existingState['toolMethod'] -ne 'ShadowHound-ADM') {
-                Write-Output ''
-                Write-Output "[!] WARNING: State file was created with $($existingState['toolMethod'])."
-                Write-Output '[!] Resuming with ShadowHound-ADM is not possible.'
-                Write-Output "[!] Path: $statePath"
-                Write-Output ''
-                while ($true) {
-                    $toolChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
-                    $toolChoice = $toolChoice.Trim().ToUpper()
-                    if ($toolChoice -eq 'Y' -or $toolChoice -eq 'YES') {
-                        Write-Output '[+] Deleting state file and starting fresh...'
-                        Remove-StateFile -Path $statePath
-                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-                        break
-                    } elseif ($toolChoice -eq 'C' -or $toolChoice -eq 'CANCEL') {
-                        Write-Output '[-] Cancelled by user'
-                        return
-                    } else {
-                        Write-Output '[!] Invalid input. Please enter Y or C.'
-                    }
-                }
-            } elseif ($existingState['executionMode']) {
-                # Check execution mode compatibility
-                $currentMode = 'Standard'
-                if ($SplitSearch -and $LetterSplitSearch) {
-                    $currentMode = 'SplitSearch+LetterSplitSearch'
-                } elseif ($SplitSearch) {
-                    $currentMode = 'SplitSearch'
-                } elseif ($LetterSplitSearch) {
-                    $currentMode = 'LetterSplitSearch'
-                }
-                
-                if ($existingState['executionMode'] -ne $currentMode) {
-                    Write-Output ''
-                    Write-Output "[!] WARNING: State file execution mode mismatch."
-                    Write-Output "[!] State file mode: $($existingState['executionMode'])"
-                    Write-Output "[!] Current execution mode: $currentMode"
-                    Write-Output '[!] Resuming with mismatched modes will cause data integrity issues.'
-                    Write-Output "[!] Path: $statePath"
-                    Write-Output ''
+                else {
                     while ($true) {
-                        $modeChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
-                        $modeChoice = $modeChoice.Trim().ToUpper()
-                        if ($modeChoice -eq 'Y' -or $modeChoice -eq 'YES') {
-                            Write-Output '[+] Deleting state file and starting fresh...'
+                        $corruptChoice = Read-Host '[?] Delete corrupted state file and start fresh? [Y]es, [C]ancel'
+                        $corruptChoice = $corruptChoice.Trim().ToUpper()
+                        if ($corruptChoice -eq 'Y' -or $corruptChoice -eq 'YES') {
+                            Write-Output '[+] Deleting corrupted state file and starting fresh...'
                             Remove-StateFile -Path $statePath
                             $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
                             break
-                        } elseif ($modeChoice -eq 'C' -or $modeChoice -eq 'CANCEL') {
+                        }
+                        elseif ($corruptChoice -eq 'C' -or $corruptChoice -eq 'CANCEL') {
                             Write-Output '[-] Cancelled by user'
                             return
-                        } else {
+                        }
+                        else {
                             Write-Output '[!] Invalid input. Please enter Y or C.'
                         }
                     }
-                } else {
-                    $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath
-                    switch ($resumeChoice) {
-                        'Y' { $stateData = $existingState }
-                        'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                        'C' { return }
-                        default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                }
+                elseif ($existingState['toolMethod'] -and $existingState['toolMethod'] -ne 'ShadowHound-ADM') {
+                    Write-Output ''
+                    Write-Output "[!] WARNING: State file was created with $($existingState['toolMethod'])."
+                    Write-Output '[!] Resuming with ShadowHound-ADM is not possible.'
+                    Write-Output "[!] Path: $statePath"
+                    Write-Output ''
+                    if ($NonInteractive) {
+                        Write-Output '[*] Non-interactive mode: Deleting state file and starting fresh...'
+                        Remove-StateFile -Path $statePath
+                        $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
                     }
-                }
-            } else {
-                $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath
-                switch ($resumeChoice) {
-                    'Y' { $stateData = $existingState }
-                    'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                    'C' { return }
-                    default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
-                }
-            }
-        } else {
-            $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
-        }
-    }
-
-    # Open StreamWriter
-    $streamWriter = New-Object System.IO.StreamWriter($OutputFilePath, $true, [System.Text.Encoding]::UTF8)
-    try {
-        $streamWriter.WriteLine('--------------------')
-        if ($Certificates) {
-
-            Write-Output '[*] Getting Configuration Naming Context...'
-            $configEnumParams = @{}
-            if ($Server) { $configEnumParams['Server'] = $Server }
-            if ($Credential) { $configEnumParams['Credential'] = $Credential }
-            $configContext = (Get-ADRootDSE @configEnumParams).ConfigurationNamingContext
-            if ($null -eq $configContext) {
-                Write-Error '[-] Failed to retrieve ConfigurationNamingContext.'
-                return
-            }
-
-            Write-Output "[*] Enumerating PKI objects under $configContext..."
-            $getAdObjectParams['SearchBase'] = $configContext
-
-            $getAdObjectParams['LdapFilter'] = '(objectClass=pKIEnrollmentService)'
-            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-            $getAdObjectParams['LdapFilter'] = '(objectClass=pKICertificateTemplate)'
-            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-            $getAdObjectParams['LdapFilter'] = '(objectClass=certificationAuthority)'
-            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-            $getAdObjectParams['LdapFilter'] = '(objectclass=msPKI-Enterprise-Oid)'
-            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-        } elseif ($SplitSearch -eq $false -and $LetterSplitSearch -eq $false) {
-
-            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-
-        } elseif ($SplitSearch -eq $true) {
-            # Get top-level containers
-            Write-Output "[*] Discovering top level containers for $Server..."
-            $topLevelContainers = Get-TopLevelContainers -Params $getAdObjectParams
-            if ($null -eq $topLevelContainers) {
-                Write-Error '[-] Something went wrong, no top-level containers found.'
-                return
-            }
-
-            # We also need to query specifically the domain object
-            $dcSearchParams = @{
-                Properties = '*'
-                LdapFilter = '(objectClass=domain)'
-            }
-
-            if ($Server) { $dcSearchParams['Server'] = $Server }
-            if ($Credential) { $dcSearchParams['Credential'] = $Credential }
-
-            Perform-ADQuery -SearchParams $dcSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                        
-            # In letter split search we need to make sure the top level containers are included
-            if ($LetterSplitSearch -eq $true) {
-                $topLevelContainers | ForEach-Object {
-                    Process-AdObject -AdObject $_ -StreamWriter $streamWriter
-                    $count.Value++
-                    if ($count.Value % $printingThreshold -eq 0) {
-                        Write-Output "[+] Queried $($Count.Value) objects so far..."
-                        $streamWriter.Flush()
-                    }
-                }
-
-
-            }
-
-
-            Write-Output "[+] Found $($topLevelContainers.Count) top-level containers."
-
-            $processedContainers = @()
-            $unprocessedContainers = @()
-
-            if ($ParsedContainers) {
-                $ParsedContainersList = Get-Content -Path $ParsedContainers
-            } else {
-                $ParsedContainersList = @()
-            }
-
-            $isFirstContainer = $true
-            foreach ($container in $topLevelContainers) {
-                $containerDN = $container.DistinguishedName
-
-                # Skip containers from ParsedContainers file
-                if ($ParsedContainersList -contains $containerDN) {
-                    Write-Output "[+] Encountered already parsed container $containerDN, skipping..."
-                    $processedContainers += $containerDN
-                    continue
-                }
-                
-                # Skip already completed containers from state file
-                if ($stateEnabled -and $stateData -and $stateData.completedContainers -contains $containerDN) {
-                    Write-Output "[+] Container $containerDN already completed, skipping..."
-                    $processedContainers += $containerDN
-                    continue
-                }
-
-                $containerSearchParams = $getAdObjectParams.Clone()
-                $containerSearchParams['SearchBase'] = $containerDN
-
-                Write-Output "[*] Processing container ($($processedContainers.Count + $unprocessedContainers.Count + 1)/$($topLevelContainers.Count)): $containerDN"
-
-                if ($LetterSplitSearch -eq $false) {
-                    try {
-                        # Process the container
-                        Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                        $processedContainers += $containerDN
-                        
-                        # Checkpoint after successful container query
-                        if ($stateEnabled -and $stateData) {
-                            $stateData.completedContainers += $containerDN
-                            $stateData.objectCount = $count.Value
-                            Write-StateFile -State $stateData -Path $statePath
+                    else {
+                        while ($true) {
+                            $toolChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
+                            $toolChoice = $toolChoice.Trim().ToUpper()
+                            if ($toolChoice -eq 'Y' -or $toolChoice -eq 'YES') {
+                                Write-Output '[+] Deleting state file and starting fresh...'
+                                Remove-StateFile -Path $statePath
+                                $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                                break
+                            }
+                            elseif ($toolChoice -eq 'C' -or $toolChoice -eq 'CANCEL') {
+                                Write-Output '[-] Cancelled by user'
+                                return
+                            }
+                            else {
+                                Write-Output '[!] Invalid input. Please enter Y or C.'
+                            }
                         }
-                    } catch {
-                        Write-Error "[-] Error processing container '$containerDN': $_"
-                        $unprocessedContainers += $containerDN
-                        continue
                     }
-                } elseif ($LetterSplitSearch -eq $true) {
+                    elseif ($existingState['executionMode']) {
+                        # Check execution mode compatibility
+                        $currentMode = 'Standard'
+                        if ($SplitSearch -and $LetterSplitSearch) {
+                            $currentMode = 'SplitSearch+LetterSplitSearch'
+                        }
+                        elseif ($SplitSearch) {
+                            $currentMode = 'SplitSearch'
+                        }
+                        elseif ($LetterSplitSearch) {
+                            $currentMode = 'LetterSplitSearch'
+                        }
+                
+                        if ($existingState['executionMode'] -ne $currentMode) {
+                            Write-Output ''
+                            Write-Output "[!] WARNING: State file execution mode mismatch."
+                            Write-Output "[!] State file mode: $($existingState['executionMode'])"
+                            Write-Output "[!] Current execution mode: $currentMode"
+                            Write-Output '[!] Resuming with mismatched modes will cause data integrity issues.'
+                            Write-Output "[!] Path: $statePath"
+                            Write-Output ''
+                            if ($NonInteractive) {
+                                Write-Output '[*] Non-interactive mode: Deleting state file and starting fresh...'
+                                Remove-StateFile -Path $statePath
+                                $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                            }
+                        }
+                        else {
+                            while ($true) {
+                                $modeChoice = Read-Host '[?] Delete state file and start fresh? [Y]es, [C]ancel'
+                                $modeChoice = $modeChoice.Trim().ToUpper()
+                                if ($modeChoice -eq 'Y' -or $modeChoice -eq 'YES') {
+                                    Write-Output '[+] Deleting state file and starting fresh...'
+                                    Remove-StateFile -Path $statePath
+                                    $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                                    break
+                                }
+                                elseif ($modeChoice -eq 'C' -or $modeChoice -eq 'CANCEL') {
+                                    Write-Output '[-] Cancelled by user'
+                                    return
+                                }
+                                else {
+                                    Write-Output '[!] Invalid input. Please enter Y or C.'
+                                }
+                            }
+                        }
+                        else {
+                            $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath -NonInteractive:$NonInteractive
+                            switch ($resumeChoice) {
+                                'Y' { $stateData = $existingState }
+                                'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                                'C' { return }
+                                default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                            }
+                        }
+                    }
+                    else {
+                        $resumeChoice = Show-StatePrompt -State $existingState -Path $statePath -NonInteractive:$NonInteractive
+                        switch ($resumeChoice) {
+                            'Y' { $stateData = $existingState }
+                            'N' { Remove-StateFile -Path $statePath; $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                            'C' { return }
+                            default { $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch }
+                        }
+                    }
+                }
+                else {
+                    $stateData = Initialize-StateFile -Path $statePath -Output $OutputFilePath -Server $Server -LdapFilter $LdapFilter -SearchBase $SearchBase -SplitSearch $SplitSearch -LetterSplitSearch $LetterSplitSearch
+                }
+            }
 
-                    # Split the search by first letter
+            # Open StreamWriter
+            $streamWriter = New-Object System.IO.StreamWriter($OutputFilePath, $true, [System.Text.Encoding]::UTF8)
+            try {
+                $streamWriter.WriteLine('--------------------')
+                if ($Certificates) {
+
+                    Write-Output '[*] Getting Configuration Naming Context...'
+                    $configEnumParams = @{}
+                    if ($Server) { $configEnumParams['Server'] = $Server }
+                    if ($Credential) { $configEnumParams['Credential'] = $Credential }
+                    $configContext = (Get-ADRootDSE @configEnumParams).ConfigurationNamingContext
+                    if ($null -eq $configContext) {
+                        Write-Error '[-] Failed to retrieve ConfigurationNamingContext.'
+                        return
+                    }
+
+                    Write-Output "[*] Enumerating PKI objects under $configContext..."
+                    $getAdObjectParams['SearchBase'] = $configContext
+
+                    $getAdObjectParams['LdapFilter'] = '(objectClass=pKIEnrollmentService)'
+                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+                    $getAdObjectParams['LdapFilter'] = '(objectClass=pKICertificateTemplate)'
+                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+                    $getAdObjectParams['LdapFilter'] = '(objectClass=certificationAuthority)'
+                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+                    $getAdObjectParams['LdapFilter'] = '(objectclass=msPKI-Enterprise-Oid)'
+                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+                }
+                elseif ($SplitSearch -eq $false -and $LetterSplitSearch -eq $false) {
+
+                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+                }
+                elseif ($SplitSearch -eq $true) {
+                    # Get top-level containers
+                    Write-Output "[*] Discovering top level containers for $Server..."
+                    $topLevelContainers = Get-TopLevelContainers -Params $getAdObjectParams
+                    if ($null -eq $topLevelContainers) {
+                        Write-Error '[-] Something went wrong, no top-level containers found.'
+                        return
+                    }
+
+                    # We also need to query specifically the domain object
+                    $dcSearchParams = @{
+                        Properties = '*'
+                        LdapFilter = '(objectClass=domain)'
+                    }
+
+                    if ($Server) { $dcSearchParams['Server'] = $Server }
+                    if ($Credential) { $dcSearchParams['Credential'] = $Credential }
+
+                    Perform-ADQuery -SearchParams $dcSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                        
+                    # In letter split search we need to make sure the top level containers are included
+                    if ($LetterSplitSearch -eq $true) {
+                        $topLevelContainers | ForEach-Object {
+                            Process-AdObject -AdObject $_ -StreamWriter $streamWriter
+                            $count.Value++
+                            if ($count.Value % $printingThreshold -eq 0) {
+                                Write-Output "[+] Queried $($Count.Value) objects so far..."
+                                $streamWriter.Flush()
+                            }
+                        }
+
+
+                    }
+
+
+                    Write-Output "[+] Found $($topLevelContainers.Count) top-level containers."
+
+                    $processedContainers = @()
+                    $unprocessedContainers = @()
+
+                    if ($ParsedContainers) {
+                        $ParsedContainersList = Get-Content -Path $ParsedContainers
+                    }
+                    else {
+                        $ParsedContainersList = @()
+                    }
+
+                    $isFirstContainer = $true
+                    foreach ($container in $topLevelContainers) {
+                        $containerDN = $container.DistinguishedName
+
+                        # Skip containers from ParsedContainers file
+                        if ($ParsedContainersList -contains $containerDN) {
+                            Write-Output "[+] Encountered already parsed container $containerDN, skipping..."
+                            $processedContainers += $containerDN
+                            continue
+                        }
+                
+                        # Skip already completed containers from state file
+                        if ($stateEnabled -and $stateData -and $stateData.completedContainers -contains $containerDN) {
+                            Write-Output "[+] Container $containerDN already completed, skipping..."
+                            $processedContainers += $containerDN
+                            continue
+                        }
+
+                        $containerSearchParams = $getAdObjectParams.Clone()
+                        $containerSearchParams['SearchBase'] = $containerDN
+
+                        Write-Output "[*] Processing container ($($processedContainers.Count + $unprocessedContainers.Count + 1)/$($topLevelContainers.Count)): $containerDN"
+
+                        if ($LetterSplitSearch -eq $false) {
+                            try {
+                                # Process the container
+                                Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                $processedContainers += $containerDN
+                        
+                                # Checkpoint after successful container query
+                                if ($stateEnabled -and $stateData) {
+                                    $stateData.completedContainers += $containerDN
+                                    $stateData.objectCount = $count.Value
+                                    Write-StateFile -State $stateData -Path $statePath
+                                }
+                            }
+                            catch {
+                                Write-Error "[-] Error processing container '$containerDN': $_"
+                                $unprocessedContainers += $containerDN
+                                continue
+                            }
+                        }
+                        elseif ($LetterSplitSearch -eq $true) {
+
+                            # Split the search by first letter
+                            # Top-level charset excludes . and - to avoid garbage queries
+                            $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
+                            # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
+                            $charsetFull = $charset + '.', '-'
+                            $OriginalFilter = $containerSearchParams['LdapFilter']
+                    
+                            # Determine starting letter for this container
+                            $startIdx = 0
+                            if ($stateEnabled -and $stateData -and $stateData.currentContainer -eq $containerDN -and $stateData.completedLetters) {
+                                # Resuming this container - use completed letters from state
+                                $completedSet = @($stateData.completedLetters)
+                            }
+                            elseif ($StartFromLetter -and $isFirstContainer) {
+                                # User specified starting letter - apply only to first container
+                                $completedSet = @()
+                                for ($i = 0; $i -lt $charset.Length; $i++) {
+                                    if ($charset[$i] -eq $StartFromLetter[0]) {
+                                        $startIdx = $i
+                                        break
+                                    }
+                                }
+                            }
+                            else {
+                                $completedSet = @()
+                            }
+                    
+                            foreach ($char in $charset[$startIdx..($charset.Length - 1)]) {
+                                $charStr = [string]$char
+                        
+                                # Skip if already completed
+                                if ($completedSet -contains $charStr) {
+                                    Write-Output "  [+] Letter '$charStr' already completed, skipping..."
+                                    continue
+                                }
+                        
+                                # Check if we have any subletters starting with this letter already completed
+                                $hasSubletters = $false
+                                foreach ($completed in $completedSet) {
+                                    if ($completed.Length -eq 2 -and $completed[0] -eq $char) {
+                                        $hasSubletters = $true
+                                        break
+                                    }
+                                }
+                        
+                                # Handle cases where we need to skip single letter and enumerate subletters:
+                                # 1. -StartFromLetter with 2-char prefix
+                                # 2. We have subletters in completedSet (resume scenario)
+                                if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
+                                    $subStartIdx = 0
+                            
+                                    # Determine starting subletter index
+                                    if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
+                                        # User specified a starting subletter
+                                        for ($i = 0; $i -lt $charset.Length; $i++) {
+                                            if ($charset[$i] -eq $StartFromLetter[1]) {
+                                                $subStartIdx = $i
+                                                break
+                                            }
+                                        }
+                                        Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
+                                    }
+                            
+                                    $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length - 1)]
+                                    foreach ($subChar in $subCharset) {
+                                        $doubleChar = "$charStr$subChar"
+                                
+                                        $isRetry = $false
+                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $isRetry = $true
+                                            Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
+                                        }
+                                
+                                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                                            continue
+                                        }
+                                
+                                        try {
+                                            Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
+                                            $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
+                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    
+                                            # Checkpoint after successful subletter query
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                                    $stateData.completedLetters += $doubleChar
+                                                }
+                                        
+                                                if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                        $stateData.failedLetters.Remove($containerDN)
+                                                    }
+                                                }
+                                        
+                                                $stateData.currentContainer = $containerDN
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                        }
+                                        catch {
+                                            Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
+                                    
+                                            # Track failed letter for this container
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not $stateData.failedLetters[$containerDN]) {
+                                                    $stateData.failedLetters[$containerDN] = @()
+                                                }
+                                                if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
+                                                    $stateData.failedLetters[$containerDN] += $doubleChar
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                            continue
+                                        }
+                                    }
+                                    continue
+                                }
+                        
+                                Write-Output "  [*] Querying $containerDN for objects with CN starting with '$charStr'"
+                                $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr*))"
+
+                                try {
+                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
+                                    # Checkpoint after successful query
+                                    if ($stateEnabled -and $stateData) {
+                                        $stateData.completedLetters += $charStr
+                                        $stateData.currentContainer = $containerDN
+                                        $stateData.objectCount = $count.Value
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                }
+                                catch {
+                                    Write-Output "   [!!] Error processing CN=$charStr* for container '$containerDN': $_`nTrying to split each letter again..."
+                                    $subCharset = $charset
+                                    foreach ($subChar in $subCharset) {
+                                        $doubleChar = "$charStr$subChar"
+                                
+                                        $isRetry = $false
+                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $isRetry = $true
+                                            Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
+                                        }
+                                
+                                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
+                                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
+                                            continue
+                                        }
+                                
+                                        try {
+                                            Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
+                                            $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
+                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    
+                                            # Checkpoint after successful subletter query
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
+                                                    $stateData.completedLetters += $doubleChar
+                                                }
+                                        
+                                                if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                        $stateData.failedLetters.Remove($containerDN)
+                                                    }
+                                                }
+                                        
+                                                $stateData.currentContainer = $containerDN
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                        }
+                                        catch {
+                                            Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
+                                    
+                                            # Track failed letter for this container
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not $stateData.failedLetters[$containerDN]) {
+                                                    $stateData.failedLetters[$containerDN] = @()
+                                                }
+                                                if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
+                                                    $stateData.failedLetters[$containerDN] += $doubleChar
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                            continue
+                                        }
+                                    }
+                                }
+                            }
+
+                            $processedContainers += $containerDN
+                            $isFirstContainer = $false
+                    
+                            if ($stateEnabled -and $stateData) {
+                                $stateData.completedContainers += $containerDN
+                                $stateData.completedLetters = @()
+                                $stateData.currentContainer = $null
+                                Write-StateFile -State $stateData -Path $statePath
+                            }
+                        }
+                    }
+
+                    # Output summary
+                    Write-Output "Processed $($count.Value) objects in total."
+                    if ($processedContainers.Count -gt 0) {
+                        Write-Output '[+] Successfully processed containers:'
+                        $processedContainers | ForEach-Object { Write-Output "  - $_" }
+                    }
+                    if ($unprocessedContainers.Count -gt 0) {
+                        Write-Output "`n[-] Failed to process containers:"
+                        $unprocessedContainers | ForEach-Object { Write-Output "    - $_" }
+                    }
+            
+                    # Report failed letters if any
+                    if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                        Write-Output ''
+                        Write-Output "[!] WARNING: Failed to enumerate letters for the following containers:"
+                        Write-Output ''
+                        foreach ($container in $stateData.failedLetters.Keys) {
+                            $letters = $stateData.failedLetters[$container] -join ', '
+                            Write-Output "  Container: $container"
+                            Write-Output "  Failed letters: $letters"
+                            Write-Output ''
+                        }
+                        Write-Output "[!] Partial or no data written for these letters before failure."
+                        Write-Output "[!] State file preserved. Resuming will retry failed letters."
+                        Write-Output ''
+                        Write-Output "[!] If failures persist, try these manual enumeration strategies:"
+                        Write-Output ''
+                        Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
+                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
+                        Write-Output "    # Targets specific year instead of broad '20*' pattern"
+                        Write-Output ''
+                        Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
+                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<failed-container-DN>' -OutputFilePath <output>"
+                        Write-Output "    # Enumerate one level deeper to reduce object count per query"
+                        Write-Output ''
+                        Write-Output "  Option 3 - Combine filters and letter splitting:"
+                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
+                        Write-Output "    # Narrow the pattern and still use letter splitting for safety"
+                        Write-Output ''
+                    }
+                }
+                elseif ($LetterSplitSearch -eq $true -and $SplitSearch -eq $false) {
                     # Top-level charset excludes . and - to avoid garbage queries
                     $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
                     # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
                     $charsetFull = $charset + '.', '-'
-                    $OriginalFilter = $containerSearchParams['LdapFilter']
-                    
-                    # Determine starting letter for this container
+                    $OriginalFilter = $getAdObjectParams['LdapFilter']
+                    $globalKey = 'global'
+            
                     $startIdx = 0
-                    if ($stateEnabled -and $stateData -and $stateData.currentContainer -eq $containerDN -and $stateData.completedLetters) {
-                        # Resuming this container - use completed letters from state
+                    $completedSet = @()
+                    if ($stateEnabled -and $stateData -and $stateData.completedLetters) {
                         $completedSet = @($stateData.completedLetters)
-                    } elseif ($StartFromLetter -and $isFirstContainer) {
-                        # User specified starting letter - apply only to first container
-                        $completedSet = @()
+                    }
+                    elseif ($StartFromLetter) {
                         for ($i = 0; $i -lt $charset.Length; $i++) {
                             if ($charset[$i] -eq $StartFromLetter[0]) {
                                 $startIdx = $i
                                 break
                             }
                         }
-                    } else {
-                        $completedSet = @()
                     }
-                    
-                    foreach ($char in $charset[$startIdx..($charset.Length-1)]) {
+            
+                    foreach ($char in $charset[$startIdx..($charset.Length - 1)]) {
                         $charStr = [string]$char
-                        
+                
                         # Skip if already completed
                         if ($completedSet -contains $charStr) {
                             Write-Output "  [+] Letter '$charStr' already completed, skipping..."
                             continue
                         }
-                        
+                
                         # Check if we have any subletters starting with this letter already completed
                         $hasSubletters = $false
                         foreach ($completed in $completedSet) {
@@ -387,13 +682,13 @@ function ShadowHound-ADM {
                                 break
                             }
                         }
-                        
+                
                         # Handle cases where we need to skip single letter and enumerate subletters:
                         # 1. -StartFromLetter with 2-char prefix
                         # 2. We have subletters in completedSet (resume scenario)
                         if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
                             $subStartIdx = 0
-                            
+                    
                             # Determine starting subletter index
                             if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
                                 # User specified a starting subletter
@@ -405,54 +700,196 @@ function ShadowHound-ADM {
                                 }
                                 Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
                             }
-                            
-                            $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length-1)]
+                    
+                            $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length - 1)]
                             foreach ($subChar in $subCharset) {
                                 $doubleChar = "$charStr$subChar"
-                                
                                 $isRetry = $false
-                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                        
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
                                     $isRetry = $true
-                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
+                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
                                 }
-                                
+                        
                                 if (($completedSet -contains $doubleChar) -and -not $isRetry) {
                                     Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
                                     continue
                                 }
+                        
+                                $hasTripleLetters = $false
+                                foreach ($completed in $completedSet) {
+                                    if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
+                                        $hasTripleLetters = $true
+                                        break
+                                    }
+                                }
+                        
+                                if ($hasTripleLetters) {
+                                    Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
+                            
+                                    # Iterate all 3-letter combinations for this 2-letter prefix
+                                    foreach ($tripleChar in $charsetFull) {
+                                        $triplePrefix = "$doubleChar$tripleChar"
                                 
+                                        # Check if already completed
+                                        if ($completedSet -contains $triplePrefix) {
+                                            Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
+                                            continue
+                                        }
+                                
+                                        # Check if in failedLetters and needs retry
+                                        $isFailedRetry = $false
+                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                            $isFailedRetry = $true
+                                            Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
+                                        }
+                                
+                                        if ($isFailedRetry) {
+                                            try {
+                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        
+                                                # Success - add to completed, remove from failed
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                        $stateData.failedLetters.Remove($globalKey)
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                                Write-Output "      [+] Successfully retried '$triplePrefix'"
+                                            }
+                                            catch {
+                                                Write-Output "      [-] Retry failed for '$triplePrefix': $_"
+                                                # Keep in failedLetters for future retry
+                                            }
+                                        }
+                                    }
+                            
+                                    continue
+                                }
+                        
                                 try {
-                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
-                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
-                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                    
+                                    Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
+                                    $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar*))"
+                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
                                     # Checkpoint after successful subletter query
                                     if ($stateEnabled -and $stateData) {
                                         if (-not ($stateData.completedLetters -contains $doubleChar)) {
                                             $stateData.completedLetters += $doubleChar
                                         }
-                                        
-                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
-                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
-                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
-                                                $stateData.failedLetters.Remove($containerDN)
+                                
+                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($globalKey)
                                             }
                                         }
-                                        
-                                        $stateData.currentContainer = $containerDN
+                                
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
-                                } catch {
-                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
-                                    
-                                    # Track failed letter for this container
-                                    if ($stateEnabled -and $stateData) {
-                                        if (-not $stateData.failedLetters[$containerDN]) {
-                                            $stateData.failedLetters[$containerDN] = @()
+                                }
+                                catch {
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
+                                    Write-Output '       Trying to split to 3-letter prefixes...'
+                            
+                                    $batchSize = 4
+                                    $tripleSuccess = $false
+                                    $failedBatches = @()
+                            
+                                    for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                        $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                        $batch = $charsetFull[$batchIdx..$batchEnd]
+                                
+                                        $orFilters = @()
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            $orFilters += "(cn=$triplePrefix*)"
                                         }
-                                        if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
-                                            $stateData.failedLetters[$containerDN] += $doubleChar
+                                
+                                        $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                        $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+                                
+                                        try {
+                                            Write-Output "  [*] Querying batch: $batchNames"
+                                            $getAdObjectParams['LdapFilter'] = $batchFilter
+                                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                            $tripleSuccess = $true
+                                    
+                                            if ($stateEnabled -and $stateData) {
+                                                foreach ($tripleChar in $batch) {
+                                                    $triplePrefix = "$doubleChar$tripleChar"
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                        }
+                                        catch {
+                                            Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
+                                            $failedBatches += , @($batch)
+                                        }
+                                    }
+                            
+                                    foreach ($batch in $failedBatches) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                    
+                                            try {
+                                                Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
+                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                                $tripleSuccess = $true
+                                        
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                            }
+                                            catch {
+                                                Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
+                                        
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not $stateData.failedLetters[$globalKey]) {
+                                                        $stateData.failedLetters[$globalKey] = @()
+                                                    }
+                                                    if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                        $stateData.failedLetters[$globalKey] += $triplePrefix
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                                continue
+                                            }
+                                        }
+                                    }
+                            
+                                    if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($globalKey)
+                                            }
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    }
+                                    elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$globalKey]) {
+                                            $stateData.failedLetters[$globalKey] = @()
+                                        }
+                                        if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
+                                            $stateData.failedLetters[$globalKey] += $doubleChar
                                         }
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
@@ -462,674 +899,308 @@ function ShadowHound-ADM {
                             }
                             continue
                         }
-                        
-                        Write-Output "  [*] Querying $containerDN for objects with CN starting with '$charStr'"
-                        $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
+                
+                        Write-Output "  [*] Querying for objects with CN starting with '$charStr'"
+                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
 
                         try {
-                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                            
+                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                    
                             # Checkpoint after successful query
                             if ($stateEnabled -and $stateData) {
                                 $stateData.completedLetters += $charStr
-                                $stateData.currentContainer = $containerDN
                                 $stateData.objectCount = $count.Value
                                 Write-StateFile -State $stateData -Path $statePath
                             }
-                        } catch {
-                            Write-Output "   [!!] Error processing CN=$charStr* for container '$containerDN': $_`nTrying to split each letter again..."
-                            $subCharset = $charset
+                        }
+                        catch {
+                            Write-Output "   [!!] Error processing character '$charStr*': $_"
+                            Write-Output '        Trying to split each letter again...'
+                            $subCharset = $charsetFull
                             foreach ($subChar in $subCharset) {
                                 $doubleChar = "$charStr$subChar"
-                                
                                 $isRetry = $false
-                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$containerDN] -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                        
+                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
                                     $isRetry = $true
-                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar' for $containerDN"
+                                    Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
                                 }
-                                
+                        
                                 if (($completedSet -contains $doubleChar) -and -not $isRetry) {
                                     Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
                                     continue
                                 }
+                        
+                                $hasTripleLetters = $false
+                                foreach ($completed in $completedSet) {
+                                    if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
+                                        $hasTripleLetters = $true
+                                        break
+                                    }
+                                }
+                        
+                                if ($hasTripleLetters) {
+                                    Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
+                            
+                                    # Iterate all 3-letter combinations for this 2-letter prefix
+                                    foreach ($tripleChar in $charsetFull) {
+                                        $triplePrefix = "$doubleChar$tripleChar"
                                 
+                                        # Check if already completed
+                                        if ($completedSet -contains $triplePrefix) {
+                                            Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
+                                            continue
+                                        }
+                                
+                                        # Check if in failedLetters and needs retry
+                                        $isFailedRetry = $false
+                                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
+                                            $isFailedRetry = $true
+                                            Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
+                                        }
+                                
+                                        if ($isFailedRetry) {
+                                            try {
+                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        
+                                                # Success - add to completed, remove from failed
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
+                                                        $stateData.failedLetters.Remove($globalKey)
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                                Write-Output "      [+] Successfully retried '$triplePrefix'"
+                                            }
+                                            catch {
+                                                Write-Output "      [-] Retry failed for '$triplePrefix': $_"
+                                                # Keep in failedLetters for future retry
+                                            }
+                                        }
+                                    }
+                            
+                                    continue
+                                }
+                        
                                 try {
-                                    Write-Output "  [*] Querying $containerDN for objects with CN starting with '$doubleChar'"
-                                    $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
-                                    Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                    
+                                    Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
+                                    $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
+                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                            
                                     # Checkpoint after successful subletter query
                                     if ($stateEnabled -and $stateData) {
                                         if (-not ($stateData.completedLetters -contains $doubleChar)) {
                                             $stateData.completedLetters += $doubleChar
                                         }
-                                        
-                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
-                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
-                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
-                                                $stateData.failedLetters.Remove($containerDN)
-                                            }
-                                        }
-                                        
-                                        $stateData.currentContainer = $containerDN
-                                        $stateData.objectCount = $count.Value
-                                        Write-StateFile -State $stateData -Path $statePath
-                                    }
-                                } catch {
-                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
-                                    
-                                    # Track failed letter for this container
-                                    if ($stateEnabled -and $stateData) {
-                                        if (-not $stateData.failedLetters[$containerDN]) {
-                                            $stateData.failedLetters[$containerDN] = @()
-                                        }
-                                        if ($stateData.failedLetters[$containerDN] -notcontains $doubleChar) {
-                                            $stateData.failedLetters[$containerDN] += $doubleChar
-                                        }
-                                        $stateData.objectCount = $count.Value
-                                        Write-StateFile -State $stateData -Path $statePath
-                                    }
-                                    continue
-                                }
-                            }
-                        }
-                    }
-
-                    $processedContainers += $containerDN
-                    $isFirstContainer = $false
-                    
-                    if ($stateEnabled -and $stateData) {
-                        $stateData.completedContainers += $containerDN
-                        $stateData.completedLetters = @()
-                        $stateData.currentContainer = $null
-                        Write-StateFile -State $stateData -Path $statePath
-                    }
-                }
-            }
-
-            # Output summary
-            Write-Output "Processed $($count.Value) objects in total."
-            if ($processedContainers.Count -gt 0) {
-                Write-Output '[+] Successfully processed containers:'
-                $processedContainers | ForEach-Object { Write-Output "  - $_" }
-            }
-            if ($unprocessedContainers.Count -gt 0) {
-                Write-Output "`n[-] Failed to process containers:"
-                $unprocessedContainers | ForEach-Object { Write-Output "    - $_" }
-            }
-            
-            # Report failed letters if any
-            if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
-                Write-Output ''
-                Write-Output "[!] WARNING: Failed to enumerate letters for the following containers:"
-                Write-Output ''
-                foreach ($container in $stateData.failedLetters.Keys) {
-                    $letters = $stateData.failedLetters[$container] -join ', '
-                    Write-Output "  Container: $container"
-                    Write-Output "  Failed letters: $letters"
-                    Write-Output ''
-                }
-                Write-Output "[!] Partial or no data written for these letters before failure."
-                Write-Output "[!] State file preserved. Resuming will retry failed letters."
-                Write-Output ''
-                Write-Output "[!] If failures persist, try these manual enumeration strategies:"
-                Write-Output ''
-                Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
-                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
-                Write-Output "    # Targets specific year instead of broad '20*' pattern"
-                Write-Output ''
-                Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
-                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<failed-container-DN>' -OutputFilePath <output>"
-                Write-Output "    # Enumerate one level deeper to reduce object count per query"
-                Write-Output ''
-                Write-Output "  Option 3 - Combine filters and letter splitting:"
-                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<failed-container-DN>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
-                Write-Output "    # Narrow the pattern and still use letter splitting for safety"
-                Write-Output ''
-            }
-        } elseif ($LetterSplitSearch -eq $true -and $SplitSearch -eq $false) {
-            # Top-level charset excludes . and - to avoid garbage queries
-            $charset = ([char[]](97..122) + [char[]](48..57) + '!', '_', '@', '$', '{', '}')
-            # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
-            $charsetFull = $charset + '.', '-'
-            $OriginalFilter = $getAdObjectParams['LdapFilter']
-            $globalKey = 'global'
-            
-            $startIdx = 0
-            $completedSet = @()
-            if ($stateEnabled -and $stateData -and $stateData.completedLetters) {
-                $completedSet = @($stateData.completedLetters)
-            } elseif ($StartFromLetter) {
-                for ($i = 0; $i -lt $charset.Length; $i++) {
-                    if ($charset[$i] -eq $StartFromLetter[0]) {
-                        $startIdx = $i
-                        break
-                    }
-                }
-            }
-            
-            foreach ($char in $charset[$startIdx..($charset.Length-1)]) {
-                $charStr = [string]$char
-                
-                # Skip if already completed
-                if ($completedSet -contains $charStr) {
-                    Write-Output "  [+] Letter '$charStr' already completed, skipping..."
-                    continue
-                }
-                
-                # Check if we have any subletters starting with this letter already completed
-                $hasSubletters = $false
-                foreach ($completed in $completedSet) {
-                    if ($completed.Length -eq 2 -and $completed[0] -eq $char) {
-                        $hasSubletters = $true
-                        break
-                    }
-                }
-                
-                # Handle cases where we need to skip single letter and enumerate subletters:
-                # 1. -StartFromLetter with 2-char prefix
-                # 2. We have subletters in completedSet (resume scenario)
-                if (($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) -or $hasSubletters) {
-                    $subStartIdx = 0
-                    
-                    # Determine starting subletter index
-                    if ($StartFromLetter -and $StartFromLetter.Length -eq 2 -and $charStr -eq $StartFromLetter[0]) {
-                        # User specified a starting subletter
-                        for ($i = 0; $i -lt $charset.Length; $i++) {
-                            if ($charset[$i] -eq $StartFromLetter[1]) {
-                                $subStartIdx = $i
-                                break
-                            }
-                        }
-                        Write-Output "  [*] Starting from double-letter '$StartFromLetter' as requested..."
-                    }
-                    
-                    $subCharset = $charsetFull[$subStartIdx..($charsetFull.Length-1)]
-                    foreach ($subChar in $subCharset) {
-                        $doubleChar = "$charStr$subChar"
-                        $isRetry = $false
-                        
-                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                            $isRetry = $true
-                            Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
-                        }
-                        
-                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
-                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
-                            continue
-                        }
-                        
-                        $hasTripleLetters = $false
-                        foreach ($completed in $completedSet) {
-                            if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
-                                $hasTripleLetters = $true
-                                break
-                            }
-                        }
-                        
-                        if ($hasTripleLetters) {
-                            Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
-                            
-                            # Iterate all 3-letter combinations for this 2-letter prefix
-                            foreach ($tripleChar in $charsetFull) {
-                                $triplePrefix = "$doubleChar$tripleChar"
                                 
-                                # Check if already completed
-                                if ($completedSet -contains $triplePrefix) {
-                                    Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
-                                    continue
-                                }
-                                
-                                # Check if in failedLetters and needs retry
-                                $isFailedRetry = $false
-                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
-                                    $isFailedRetry = $true
-                                    Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
-                                }
-                                
-                                if ($isFailedRetry) {
-                                    try {
-                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                        
-                                        # Success - add to completed, remove from failed
-                                        if ($stateEnabled -and $stateData) {
-                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                $stateData.completedLetters += $triplePrefix
-                                            }
-                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
                                             if ($stateData.failedLetters[$globalKey].Count -eq 0) {
                                                 $stateData.failedLetters.Remove($globalKey)
                                             }
-                                            $stateData.objectCount = $count.Value
-                                            Write-StateFile -State $stateData -Path $statePath
                                         }
-                                        Write-Output "      [+] Successfully retried '$triplePrefix'"
-                                    } catch {
-                                        Write-Output "      [-] Retry failed for '$triplePrefix': $_"
-                                        # Keep in failedLetters for future retry
-                                    }
-                                }
-                            }
-                            
-                            continue
-                        }
-                        
-                        try {
-                            Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
-                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
-                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                            
-                            # Checkpoint after successful subletter query
-                            if ($stateEnabled -and $stateData) {
-                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
-                                    $stateData.completedLetters += $doubleChar
-                                }
                                 
-                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                        $stateData.failedLetters.Remove($globalKey)
-                                    }
-                                }
-                                
-                                $stateData.objectCount = $count.Value
-                                Write-StateFile -State $stateData -Path $statePath
-                            }
-                        } catch {
-                            Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
-                            Write-Output '       Trying to split to 3-letter prefixes...'
-                            
-                            $batchSize = 4
-                            $tripleSuccess = $false
-                            $failedBatches = @()
-                            
-                            for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
-                                $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
-                                $batch = $charsetFull[$batchIdx..$batchEnd]
-                                
-                                $orFilters = @()
-                                foreach ($tripleChar in $batch) {
-                                    $triplePrefix = "$doubleChar$tripleChar"
-                                    $orFilters += "(cn=$triplePrefix*)"
-                                }
-                                
-                                $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
-                                $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
-                                
-                                try {
-                                    Write-Output "  [*] Querying batch: $batchNames"
-                                    $getAdObjectParams['LdapFilter'] = $batchFilter
-                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                    $tripleSuccess = $true
-                                    
-                                    if ($stateEnabled -and $stateData) {
-                                        foreach ($tripleChar in $batch) {
-                                            $triplePrefix = "$doubleChar$tripleChar"
-                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                $stateData.completedLetters += $triplePrefix
-                                            }
-                                        }
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
-                                } catch {
-                                    Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
-                                    $failedBatches += ,@($batch)
                                 }
-                            }
+                                catch {
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
+                                    Write-Output '       Trying to split to 3-letter prefixes...'
                             
-                            foreach ($batch in $failedBatches) {
-                                foreach ($tripleChar in $batch) {
-                                    $triplePrefix = "$doubleChar$tripleChar"
+                                    $batchSize = 4
+                                    $tripleSuccess = $false
+                                    $failedBatches = @()
+                            
+                                    for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                        $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                        $batch = $charsetFull[$batchIdx..$batchEnd]
+                                
+                                        $orFilters = @()
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            $orFilters += "(cn=$triplePrefix*)"
+                                        }
+                                
+                                        $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                        $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+                                
+                                        try {
+                                            Write-Output "  [*] Querying batch: $batchNames"
+                                            $getAdObjectParams['LdapFilter'] = $batchFilter
+                                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                            $tripleSuccess = $true
                                     
-                                    try {
-                                        Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
-                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                        $tripleSuccess = $true
-                                        
-                                        if ($stateEnabled -and $stateData) {
-                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                $stateData.completedLetters += $triplePrefix
+                                            if ($stateEnabled -and $stateData) {
+                                                foreach ($tripleChar in $batch) {
+                                                    $triplePrefix = "$doubleChar$tripleChar"
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
                                             }
-                                            $stateData.objectCount = $count.Value
-                                            Write-StateFile -State $stateData -Path $statePath
                                         }
-                                    } catch {
-                                        Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
-                                        
-                                        if ($stateEnabled -and $stateData) {
-                                            if (-not $stateData.failedLetters[$globalKey]) {
-                                                $stateData.failedLetters[$globalKey] = @()
-                                            }
-                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
-                                                $stateData.failedLetters[$globalKey] += $triplePrefix
-                                            }
-                                            $stateData.objectCount = $count.Value
-                                            Write-StateFile -State $stateData -Path $statePath
+                                        catch {
+                                            Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
+                                            $failedBatches += , @($batch)
                                         }
-                                        continue
                                     }
-                                }
-                            }
                             
-                            if ($tripleSuccess -and $stateEnabled -and $stateData) {
-                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                        $stateData.failedLetters.Remove($globalKey)
-                                    }
-                                    Write-StateFile -State $stateData -Path $statePath
-                                }
-                            } elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
-                                if (-not $stateData.failedLetters[$globalKey]) {
-                                    $stateData.failedLetters[$globalKey] = @()
-                                }
-                                if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
-                                    $stateData.failedLetters[$globalKey] += $doubleChar
-                                }
-                                $stateData.objectCount = $count.Value
-                                Write-StateFile -State $stateData -Path $statePath
-                            }
-                            continue
-                        }
-                    }
-                    continue
-                }
-                
-                Write-Output "  [*] Querying for objects with CN starting with '$charStr'"
-                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr**))"
-
-                try {
-                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                    
-                    # Checkpoint after successful query
-                    if ($stateEnabled -and $stateData) {
-                        $stateData.completedLetters += $charStr
-                        $stateData.objectCount = $count.Value
-                        Write-StateFile -State $stateData -Path $statePath
-                    }
-                } catch {
-                    Write-Output "   [!!] Error processing character '$charStr*': $_"
-                    Write-Output '        Trying to split each letter again...'
-                    $subCharset = $charsetFull
-                    foreach ($subChar in $subCharset) {
-                        $doubleChar = "$charStr$subChar"
-                        $isRetry = $false
-                        
-                        if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                            $isRetry = $true
-                            Write-Output "  [*] Retrying previously failed letter '$doubleChar'"
-                        }
-                        
-                        if (($completedSet -contains $doubleChar) -and -not $isRetry) {
-                            Write-Output "    [+] Letter '$doubleChar' already completed, skipping..."
-                            continue
-                        }
-                        
-                        $hasTripleLetters = $false
-                        foreach ($completed in $completedSet) {
-                            if ($completed.Length -eq 3 -and $completed.StartsWith($doubleChar)) {
-                                $hasTripleLetters = $true
-                                break
-                            }
-                        }
-                        
-                        if ($hasTripleLetters) {
-                            Write-Output "    [+] Letter '$doubleChar' has 3-letter subletters, iterating those..."
-                            
-                            # Iterate all 3-letter combinations for this 2-letter prefix
-                            foreach ($tripleChar in $charsetFull) {
-                                $triplePrefix = "$doubleChar$tripleChar"
-                                
-                                # Check if already completed
-                                if ($completedSet -contains $triplePrefix) {
-                                    Write-Output "      [+] Letter '$triplePrefix' already completed, skipping..."
-                                    continue
-                                }
-                                
-                                # Check if in failedLetters and needs retry
-                                $isFailedRetry = $false
-                                if ($stateEnabled -and $stateData -and $stateData.failedLetters[$globalKey] -and $stateData.failedLetters[$globalKey] -contains $triplePrefix) {
-                                    $isFailedRetry = $true
-                                    Write-Output "      [*] Retrying previously failed letter '$triplePrefix'"
-                                }
-                                
-                                if ($isFailedRetry) {
-                                    try {
-                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                    foreach ($batch in $failedBatches) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                    
+                                            try {
+                                                Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
+                                                $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                                Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                                $tripleSuccess = $true
                                         
-                                        # Success - add to completed, remove from failed
-                                        if ($stateEnabled -and $stateData) {
-                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                $stateData.completedLetters += $triplePrefix
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
                                             }
-                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $triplePrefix })
+                                            catch {
+                                                Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
+                                        
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not $stateData.failedLetters[$globalKey]) {
+                                                        $stateData.failedLetters[$globalKey] = @()
+                                                    }
+                                                    if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
+                                                        $stateData.failedLetters[$globalKey] += $triplePrefix
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                                continue
+                                            }
+                                        }
+                                    }
+                            
+                                    if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                        if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
+                                            $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
                                             if ($stateData.failedLetters[$globalKey].Count -eq 0) {
                                                 $stateData.failedLetters.Remove($globalKey)
                                             }
-                                            $stateData.objectCount = $count.Value
                                             Write-StateFile -State $stateData -Path $statePath
                                         }
-                                        Write-Output "      [+] Successfully retried '$triplePrefix'"
-                                    } catch {
-                                        Write-Output "      [-] Retry failed for '$triplePrefix': $_"
-                                        # Keep in failedLetters for future retry
                                     }
-                                }
-                            }
-                            
-                            continue
-                        }
-                        
-                        try {
-                            Write-Output "  [*] Querying for objects with CN starting with '$doubleChar'"
-                            $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$doubleChar**))"
-                            Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                            
-                            # Checkpoint after successful subletter query
-                            if ($stateEnabled -and $stateData) {
-                                if (-not ($stateData.completedLetters -contains $doubleChar)) {
-                                    $stateData.completedLetters += $doubleChar
-                                }
-                                
-                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                        $stateData.failedLetters.Remove($globalKey)
-                                    }
-                                }
-                                
-                                $stateData.objectCount = $count.Value
-                                Write-StateFile -State $stateData -Path $statePath
-                            }
-                        } catch {
-                            Write-Output "   [-] Failed to process (CN=$doubleChar*): $_"
-                            Write-Output '       Trying to split to 3-letter prefixes...'
-                            
-                            $batchSize = 4
-                            $tripleSuccess = $false
-                            $failedBatches = @()
-                            
-                            for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
-                                $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
-                                $batch = $charsetFull[$batchIdx..$batchEnd]
-                                
-                                $orFilters = @()
-                                foreach ($tripleChar in $batch) {
-                                    $triplePrefix = "$doubleChar$tripleChar"
-                                    $orFilters += "(cn=$triplePrefix*)"
-                                }
-                                
-                                $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
-                                $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
-                                
-                                try {
-                                    Write-Output "  [*] Querying batch: $batchNames"
-                                    $getAdObjectParams['LdapFilter'] = $batchFilter
-                                    Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                    $tripleSuccess = $true
-                                    
-                                    if ($stateEnabled -and $stateData) {
-                                        foreach ($tripleChar in $batch) {
-                                            $triplePrefix = "$doubleChar$tripleChar"
-                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                $stateData.completedLetters += $triplePrefix
-                                            }
+                                    elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
+                                        if (-not $stateData.failedLetters[$globalKey]) {
+                                            $stateData.failedLetters[$globalKey] = @()
+                                        }
+                                        if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
+                                            $stateData.failedLetters[$globalKey] += $doubleChar
                                         }
                                         $stateData.objectCount = $count.Value
                                         Write-StateFile -State $stateData -Path $statePath
                                     }
-                                } catch {
-                                    Write-Output "   [-] Batch failed - will retry failed batch individually after completing remaining batches"
-                                    $failedBatches += ,@($batch)
+                                    continue
                                 }
                             }
-                            
-                            foreach ($batch in $failedBatches) {
-                                foreach ($tripleChar in $batch) {
-                                    $triplePrefix = "$doubleChar$tripleChar"
-                                    
-                                    try {
-                                        Write-Output "  [*] Querying for objects with CN starting with '$triplePrefix'"
-                                        $getAdObjectParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
-                                        Perform-ADQuery -SearchParams $getAdObjectParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
-                                        $tripleSuccess = $true
-                                        
-                                        if ($stateEnabled -and $stateData) {
-                                            if (-not ($stateData.completedLetters -contains $triplePrefix)) {
-                                                $stateData.completedLetters += $triplePrefix
-                                            }
-                                            $stateData.objectCount = $count.Value
-                                            Write-StateFile -State $stateData -Path $statePath
-                                        }
-                                    } catch {
-                                        Write-Output "   [-] Failed to process (CN=$triplePrefix*): $_"
-                                        
-                                        if ($stateEnabled -and $stateData) {
-                                            if (-not $stateData.failedLetters[$globalKey]) {
-                                                $stateData.failedLetters[$globalKey] = @()
-                                            }
-                                            if ($stateData.failedLetters[$globalKey] -notcontains $triplePrefix) {
-                                                $stateData.failedLetters[$globalKey] += $triplePrefix
-                                            }
-                                            $stateData.objectCount = $count.Value
-                                            Write-StateFile -State $stateData -Path $statePath
-                                        }
-                                        continue
-                                    }
-                                }
-                            }
-                            
-                            if ($tripleSuccess -and $stateEnabled -and $stateData) {
-                                if ($stateData.failedLetters.ContainsKey($globalKey) -and $stateData.failedLetters[$globalKey] -contains $doubleChar) {
-                                    $stateData.failedLetters[$globalKey] = @($stateData.failedLetters[$globalKey] | Where-Object { $_ -ne $doubleChar })
-                                    if ($stateData.failedLetters[$globalKey].Count -eq 0) {
-                                        $stateData.failedLetters.Remove($globalKey)
-                                    }
-                                    Write-StateFile -State $stateData -Path $statePath
-                                }
-                            } elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
-                                if (-not $stateData.failedLetters[$globalKey]) {
-                                    $stateData.failedLetters[$globalKey] = @()
-                                }
-                                if ($stateData.failedLetters[$globalKey] -notcontains $doubleChar) {
-                                    $stateData.failedLetters[$globalKey] += $doubleChar
-                                }
-                                $stateData.objectCount = $count.Value
-                                Write-StateFile -State $stateData -Path $statePath
-                            }
-                            continue
                         }
                     }
-                }
-            }
             
-            if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
-                Write-Output ''
-                Write-Output "[!] WARNING: Failed to enumerate the following letters:"
-                if ($stateData.failedLetters[$globalKey]) {
-                    $letters = $stateData.failedLetters[$globalKey] -join ', '
-                    Write-Output "  Failed letters: $letters"
+                    if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                        Write-Output ''
+                        Write-Output "[!] WARNING: Failed to enumerate the following letters:"
+                        if ($stateData.failedLetters[$globalKey]) {
+                            $letters = $stateData.failedLetters[$globalKey] -join ', '
+                            Write-Output "  Failed letters: $letters"
+                        }
+                        Write-Output ''
+                        Write-Output "[!] Partial or no data written for these letters before failure."
+                        Write-Output "[!] State file preserved. Resuming will retry failed letters."
+                        Write-Output ''
+                        Write-Output "[!] If failures persist, try these manual enumeration strategies:"
+                        Write-Output ''
+                        Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
+                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
+                        Write-Output "    # Targets specific year instead of broad '20*' pattern"
+                        Write-Output ''
+                        Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
+                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<search-base>' -OutputFilePath <output>"
+                        Write-Output "    # Enumerate one level deeper to reduce object count per query"
+                        Write-Output ''
+                        Write-Output "  Option 3 - Combine filters and letter splitting:"
+                        Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
+                        Write-Output "    # Narrow the pattern and still use letter splitting for safety"
+                        Write-Output ''
+                    }
                 }
-                Write-Output ''
-                Write-Output "[!] Partial or no data written for these letters before failure."
-                Write-Output "[!] State file preserved. Resuming will retry failed letters."
-                Write-Output ''
-                Write-Output "[!] If failures persist, try these manual enumeration strategies:"
-                Write-Output ''
-                Write-Output "  Option 1 - More specific CN filter using -LdapFilter:"
-                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=2024*))' -OutputFilePath <output>"
-                Write-Output "    # Targets specific year instead of broad '20*' pattern"
-                Write-Output ''
-                Write-Output "  Option 2 - Target a specific sub-OU to reduce scope:"
-                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase 'OU=SubOU,<search-base>' -OutputFilePath <output>"
-                Write-Output "    # Enumerate one level deeper to reduce object count per query"
-                Write-Output ''
-                Write-Output "  Option 3 - Combine filters and letter splitting:"
-                Write-Output "    ShadowHound-ADM -Server <server> -SearchBase '<search-base>' -LdapFilter '(&(objectGuid=*)(cn=202*))' -LetterSplitSearch -OutputFilePath <output>"
-                Write-Output "    # Narrow the pattern and still use letter splitting for safety"
-                Write-Output ''
+
+
+                $summaryLine = "Retrieved $($count.Value) results total"
+                $streamWriter.WriteLine($summaryLine)
+            }
+            finally {
+                $streamWriter.Flush()
+                $streamWriter.Close()
+            }
+
+            # State cleanup on completion
+            if ($stateEnabled -and $statePath -and -not $KeepStateFile) {
+                # Only remove state file if no failures occurred
+                if ($stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
+                    Write-Output '[*] State file preserved due to failed letters:' $statePath
+                }
+                else {
+                    Write-Output '[*] Enumeration complete, removing state file...'
+                    Remove-StateFile -Path $statePath
+                }
+            }
+            elseif ($stateEnabled -and $KeepStateFile) {
+                Write-Output '[*] State file preserved:' $statePath
+            }
+
+            Write-Output "Objects have been processed and written to $OutputFilePath"
+            Write-Output $summaryLine
+            Write-Output '==================================================='
+
+            # Handle recursion if necessary
+            if ($Recurse -and $unprocessedContainers.Count -gt 0) {
+                Write-Output "[*] Current SearchBase is $SearchBase"
+                Write-Output "[*] Attempting to recurse $($unprocessedContainers.Count) failed containers/OUs:"
+                foreach ($failedContainer in $unprocessedContainers) {
+                    Write-Output $failedContainer
+
+                    $recurseParams = @{
+                        OutputFilePath = "$($failedContainer.Split(',')[0].Split('=')[1])_$OutputFilePath"
+                        SearchBase     = $failedContainer
+                        SplitSearch    = $true
+                        Recurse        = $true
+                    }
+                    if ($Server) { $recurseParams['Server'] = $Server }
+                    if ($Credential) { $recurseParams['Credential'] = $Credential }
+                    if ($ParsedContainers) { $recurseParams['ParsedContainers'] = $ParsedContainers }
+                    if ($LdapFilter) { $recurseParams['LdapFilter'] = $LdapFilter }
+
+                    if ($LetterSplitSearch) {
+                        $recurseParams['LetterSplitSearch'] = $true
+                    }
+
+                    Write-Output "[+] Attempting to recurse $failedContainer"
+                    ShadowHound-ADM @recurseParams
+                }
             }
         }
 
-
-        $summaryLine = "Retrieved $($count.Value) results total"
-        $streamWriter.WriteLine($summaryLine)
-    } finally {
-        $streamWriter.Flush()
-        $streamWriter.Close()
-    }
-
-    # State cleanup on completion
-    if ($stateEnabled -and $statePath -and -not $KeepStateFile) {
-        # Only remove state file if no failures occurred
-        if ($stateData -and $stateData.failedLetters -and $stateData.failedLetters.Count -gt 0) {
-            Write-Output '[*] State file preserved due to failed letters:' $statePath
-        } else {
-            Write-Output '[*] Enumeration complete, removing state file...'
-            Remove-StateFile -Path $statePath
-        }
-    } elseif ($stateEnabled -and $KeepStateFile) {
-        Write-Output '[*] State file preserved:' $statePath
-    }
-
-    Write-Output "Objects have been processed and written to $OutputFilePath"
-    Write-Output $summaryLine
-    Write-Output '==================================================='
-
-    # Handle recursion if necessary
-    if ($Recurse -and $unprocessedContainers.Count -gt 0) {
-        Write-Output "[*] Current SearchBase is $SearchBase"
-        Write-Output "[*] Attempting to recurse $($unprocessedContainers.Count) failed containers/OUs:"
-        foreach ($failedContainer in $unprocessedContainers) {
-            Write-Output $failedContainer
-
-            $recurseParams = @{
-                OutputFilePath = "$($failedContainer.Split(',')[0].Split('=')[1])_$OutputFilePath"
-                SearchBase     = $failedContainer
-                SplitSearch    = $true
-                Recurse        = $true
-            }
-            if ($Server) { $recurseParams['Server'] = $Server }
-            if ($Credential) { $recurseParams['Credential'] = $Credential }
-            if ($ParsedContainers) { $recurseParams['ParsedContainers'] = $ParsedContainers }
-            if ($LdapFilter) { $recurseParams['LdapFilter'] = $LdapFilter }
-
-            if ($LetterSplitSearch) {
-                $recurseParams['LetterSplitSearch'] = $true
-            }
-
-            Write-Output "[+] Attempting to recurse $failedContainer"
-            ShadowHound-ADM @recurseParams
-        }
-    }
-}
-
-function Print-Logo {
-    $logo = @'
+        function Print-Logo {
+            $logo = @'
 .........................................................................
 :  ____  _               _               _   _                       _  :
 : / ___|| |__   __ _  __| | _____      _| | | | ___  _   _ _ __   __| | :
@@ -1140,12 +1211,12 @@ function Print-Logo {
 :   Author: Yehuda Smirnov (X: @yudasm_ BlueSky: @yudasm.bsky.social)   :
 .........................................................................
 '@
-    Write-Output $logo
-}
+            Write-Output $logo
+        }
 
-function Print-Help {
-    Print-Logo
-    $helpMessage = '
+        function Print-Help {
+            Print-Logo
+            $helpMessage = '
 ShadowHound-ADM Help
 
 SYNTAX:
@@ -1233,511 +1304,541 @@ EXAMPLES:
     # Example 8: Disable state file for zero artifacts
     ShadowHound-ADM -OutputFilePath "C:\Results\output.txt" -LetterSplitSearch -DisableStateFile
 '
-    Write-Host $helpMessage
-    return
-}
-
-function Process-AdObject {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [Microsoft.ActiveDirectory.Management.ADObject]$AdObject,
-
-        [Parameter(Mandatory = $true)]
-        [System.IO.StreamWriter]$StreamWriter
-    )
-
-    # Define ignored properties
-    $ignoredValues = @(
-        'CanonicalName', 'PropertyNames', 'AddedProperties', 'RemovedProperties',
-        'ModifiedProperties', 'PropertyCount', 'repsTo', 'ProtectedFromAccidentalDeletion',
-        'sDRightsEffective', 'modifyTimeStamp', 'Modified', 'createTimeStamp',
-        'Created', 'userCertificate'
-    )
-
-    # Map object classes
-    $objectClassMapping = @{
-        'applicationSettings'                  = 'top, applicationSettings, nTFRSSettings'
-        'builtinDomain'                        = 'top, builtinDomain'
-        'classStore'                           = 'top, classStore'
-        'container'                            = 'top, container'
-        'groupPolicyContainer'                 = 'top, container, groupPolicyContainer'
-        'msImaging-PSPs'                       = 'top, container, msImaging-PSPs'
-        'rpcContainer'                         = 'top, container, rpcContainer'
-        'dfsConfiguration'                     = 'top, dfsConfiguration'
-        'dnsNode'                              = 'top, dnsNode'
-        'dnsZone'                              = 'top, dnsZone'
-        'domainDNS'                            = 'top, domain, domainDNS'
-        'fileLinkTracking'                     = 'top, fileLinkTracking'
-        'linkTrackObjectMoveTable'             = 'top, fileLinkTracking, linkTrackObjectMoveTable'
-        'linkTrackVolumeTable'                 = 'top, fileLinkTracking, linkTrackVolumeTable'
-        'foreignSecurityPrincipal'             = 'top, foreignSecurityPrincipal'
-        'group'                                = 'top, group'
-        'infrastructureUpdate'                 = 'top, infrastructureUpdate'
-        'ipsecFilter'                          = 'top, ipsecBase, ipsecFilter'
-        'ipsecISAKMPPolicy'                    = 'top, ipsecBase, ipsecISAKMPPolicy'
-        'ipsecNegotiationPolicy'               = 'top, ipsecBase, ipsecNegotiationPolicy'
-        'ipsecNFA'                             = 'top, ipsecBase, ipsecNFA'
-        'ipsecPolicy'                          = 'top, ipsecBase, ipsecPolicy'
-        'domainPolicy'                         = 'top, leaf, domainPolicy'
-        'secret'                               = 'top, leaf, secret'
-        'trustedDomain'                        = 'top, leaf, trustedDomain'
-        'lostAndFound'                         = 'top, lostAndFound'
-        'msDFSR-Content'                       = 'top, msDFSR-Content'
-        'msDFSR-ContentSet'                    = 'top, msDFSR-ContentSet'
-        'msDFSR-GlobalSettings'                = 'top, msDFSR-GlobalSettings'
-        'msDFSR-LocalSettings'                 = 'top, msDFSR-LocalSettings'
-        'msDFSR-Member'                        = 'top, msDFSR-Member'
-        'msDFSR-ReplicationGroup'              = 'top, msDFSR-ReplicationGroup'
-        'msDFSR-Subscriber'                    = 'top, msDFSR-Subscriber'
-        'msDFSR-Subscription'                  = 'top, msDFSR-Subscription'
-        'msDFSR-Topology'                      = 'top, msDFSR-Topology'
-        'msDS-PasswordSettingsContainer'       = 'top, msDS-PasswordSettingsContainer'
-        'msDS-QuotaContainer'                  = 'top, msDS-QuotaContainer'
-        'msTPM-InformationObjectsContainer'    = 'top, msTPM-InformationObjectsContainer'
-        'organizationalUnit'                   = 'top, organizationalUnit'
-        'contact'                              = 'top, person, organizationalPerson, contact'
-        'user'                                 = 'top, person, organizationalPerson, user'
-        'computer'                             = 'top, person, organizationalPerson, user, computer'
-        'rIDManager'                           = 'top, rIDManager'
-        'rIDSet'                               = 'top, rIDSet'
-        'samServer'                            = 'top, securityObject, samServer'
-        'msExchSystemObjectsContainer'         = 'top, container, msExchSystemObjectsContainer'
-        'msRTCSIP-ApplicationContacts'         = 'top, container, msRTCSIP-ApplicationContacts'
-        'msRTCSIP-ArchivingServer'             = 'top, container, msRTCSIP-ArchivingServer'
-        'msRTCSIP-ConferenceDirectories'       = 'top, container, msRTCSIP-ConferenceDirectories'
-        'msRTCSIP-ConferenceDirectory'         = 'top, container, msRTCSIP-ConferenceDirectory'
-        'msRTCSIP-Domain'                      = 'top, container, msRTCSIP-Domain'
-        'msRTCSIP-EdgeProxy'                   = 'top, container, msRTCSIP-EdgeProxy'
-        'msRTCSIP-GlobalContainer'             = 'top, container, msRTCSIP-GlobalContainer'
-        'msRTCSIP-GlobalTopologySetting'       = 'top, container, msRTCSIP-GlobalTopologySetting'
-        'msRTCSIP-GlobalTopologySettings'      = 'top, container, msRTCSIP-GlobalTopologySettings'
-        'msRTCSIP-GlobalUserPolicy'            = 'top, container, msRTCSIP-GlobalUserPolicy'
-        'msRTCSIP-LocalNormalization'          = 'top, container, msRTCSIP-LocalNormalization'
-        'msRTCSIP-LocalNormalizations'         = 'top, container, msRTCSIP-LocalNormalizations'
-        'msRTCSIP-LocationContactMapping'      = 'top, container, msRTCSIP-LocationContactMapping'
-        'msRTCSIP-LocationContactMappings'     = 'top, container, msRTCSIP-LocationContactMappings'
-        'msRTCSIP-LocationProfile'             = 'top, container, msRTCSIP-LocationProfile'
-        'msRTCSIP-LocationProfiles'            = 'top, container, msRTCSIP-LocationProfiles'
-        'msRTCSIP-MCUFactories'                = 'top, container, msRTCSIP-MCUFactories'
-        'msRTCSIP-MCUFactory'                  = 'top, container, msRTCSIP-MCUFactory'
-        'msRTCSIP-MonitoringServer'            = 'top, container, msRTCSIP-MonitoringServer'
-        'msRTCSIP-PhoneRoute'                  = 'top, container, msRTCSIP-PhoneRoute'
-        'msRTCSIP-PhoneRoutes'                 = 'top, container, msRTCSIP-PhoneRoutes'
-        'msRTCSIP-Policies'                    = 'top, container, msRTCSIP-Policies'
-        'msRTCSIP-Pool'                        = 'top, container, msRTCSIP-Pool'
-        'msRTCSIP-Pools'                       = 'top, container, msRTCSIP-Pools'
-        'msRTCSIP-RouteUsage'                  = 'top, container, msRTCSIP-RouteUsage'
-        'msRTCSIP-RouteUsages'                 = 'top, container, msRTCSIP-RouteUsages'
-        'msRTCSIP-TrustedMCU'                  = 'top, container, msRTCSIP-TrustedMCU'
-        'msRTCSIP-TrustedMCUs'                 = 'top, container, msRTCSIP-TrustedMCUs'
-        'msRTCSIP-TrustedProxies'              = 'top, container, msRTCSIP-TrustedProxies'
-        'msRTCSIP-TrustedServer'               = 'top, container, msRTCSIP-TrustedServer'
-        'msRTCSIP-TrustedService'              = 'top, container, msRTCSIP-TrustedService'
-        'msRTCSIP-TrustedServices'             = 'top, container, msRTCSIP-TrustedServices'
-        'msRTCSIP-TrustedWebComponentsServer'  = 'top, container, msRTCSIP-TrustedWebComponentsServer'
-        'msRTCSIP-TrustedWebComponentsServers' = 'top, container, msRTCSIP-TrustedWebComponentsServers'
-        'msWMI-Som'                            = 'top, msWMI-Som'
-        'nTFRSReplicaSet'                      = 'top, nTFRSReplicaSet'
-        'packageRegistration'                  = 'top, packageRegistration'
-        'msDS-GroupManagedServiceAccount'      = 'top, person, organizationalPerson, user, computer, msDS-GroupManagedServiceAccount'
-        'pKIEnrollmentService'                 = 'top, pKIEnrollmentService'
-        'nTFRSSettings'                        = 'top, applicationSettings, nTFRSSettings'
-        'rpcServer'                            = 'top, leaf, connectionPoint, rpcEntry, rpcServer'
-        'rpcServerElement'                     = 'top, leaf, connectionPoint, rpcEntry, rpcServerElement'
-        'serviceConnectionPoint'               = 'top, leaf, connectionPoint, serviceConnectionPoint'
-        'msRTCSIP-ApplicationServerService'    = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-ApplicationServerService'
-        'msRTCSIP-MCUFactoryService'           = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-MCUFactoryService'
-        'msRTCSIP-PoolService'                 = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-PoolService'
-        'msRTCSIP-Service'                     = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-Service'
-        'msRTCSIP-WebComponentsService'        = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-WebComponentsService'
-        'pKICertificateTemplate'               = 'top, pKICertificateTemplate'
-        'certificationAuthority'               = 'top, certificationAuthority'
-        'msPKI-Enterprise-Oid'                 = 'top, msPKI-Enterprise-Oid'
-    }
-
-    if ($null -eq $AdObject) {
-        Write-Error 'AdObject is null'
-        return
-    }
-
-    $outputLines = New-Object System.Collections.Generic.List[string]
-    $outputLines.Add('--------------------')
-
-    foreach ($property in $AdObject.PSObject.Properties) {
-        $name = $property.Name
-        $value = $property.Value
-
-        # Skip properties with empty values and unwanted properties
-        if ($null -eq $value -or ($value -is [string] -and [string]::IsNullOrWhiteSpace($value)) -or $ignoredValues -contains $name) {
-            continue
+            Write-Host $helpMessage
+            return
         }
 
-        # Cache type checks
-        $isDateTime = $value -is [datetime]
-        $isByteArray = $value -is [byte[]]
-        $isGuid = $value -is [guid]
-        $isCollection = $value -is [Microsoft.ActiveDirectory.Management.ADPropertyValueCollection]
+        function Process-AdObject {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [Microsoft.ActiveDirectory.Management.ADObject]$AdObject,
 
-        switch ($name) {
-            'nTSecurityDescriptor' {
-                if ($null -ne $value) {
-                    $binaryForm = $value.GetSecurityDescriptorBinaryForm()
-                    if ($binaryForm.Length -gt 0) {
-                        $base64Value = [System.Convert]::ToBase64String($binaryForm)
-                        $outputLines.Add("$name`: $base64Value")
-                    }
-                }
-                break
+                [Parameter(Mandatory = $true)]
+                [System.IO.StreamWriter]$StreamWriter
+            )
+
+            # Define ignored properties
+            $ignoredValues = @(
+                'CanonicalName', 'PropertyNames', 'AddedProperties', 'RemovedProperties',
+                'ModifiedProperties', 'PropertyCount', 'repsTo', 'ProtectedFromAccidentalDeletion',
+                'sDRightsEffective', 'modifyTimeStamp', 'Modified', 'createTimeStamp',
+                'Created', 'userCertificate'
+            )
+
+            # Map object classes
+            $objectClassMapping = @{
+                'applicationSettings'                  = 'top, applicationSettings, nTFRSSettings'
+                'builtinDomain'                        = 'top, builtinDomain'
+                'classStore'                           = 'top, classStore'
+                'container'                            = 'top, container'
+                'groupPolicyContainer'                 = 'top, container, groupPolicyContainer'
+                'msImaging-PSPs'                       = 'top, container, msImaging-PSPs'
+                'rpcContainer'                         = 'top, container, rpcContainer'
+                'dfsConfiguration'                     = 'top, dfsConfiguration'
+                'dnsNode'                              = 'top, dnsNode'
+                'dnsZone'                              = 'top, dnsZone'
+                'domainDNS'                            = 'top, domain, domainDNS'
+                'fileLinkTracking'                     = 'top, fileLinkTracking'
+                'linkTrackObjectMoveTable'             = 'top, fileLinkTracking, linkTrackObjectMoveTable'
+                'linkTrackVolumeTable'                 = 'top, fileLinkTracking, linkTrackVolumeTable'
+                'foreignSecurityPrincipal'             = 'top, foreignSecurityPrincipal'
+                'group'                                = 'top, group'
+                'infrastructureUpdate'                 = 'top, infrastructureUpdate'
+                'ipsecFilter'                          = 'top, ipsecBase, ipsecFilter'
+                'ipsecISAKMPPolicy'                    = 'top, ipsecBase, ipsecISAKMPPolicy'
+                'ipsecNegotiationPolicy'               = 'top, ipsecBase, ipsecNegotiationPolicy'
+                'ipsecNFA'                             = 'top, ipsecBase, ipsecNFA'
+                'ipsecPolicy'                          = 'top, ipsecBase, ipsecPolicy'
+                'domainPolicy'                         = 'top, leaf, domainPolicy'
+                'secret'                               = 'top, leaf, secret'
+                'trustedDomain'                        = 'top, leaf, trustedDomain'
+                'lostAndFound'                         = 'top, lostAndFound'
+                'msDFSR-Content'                       = 'top, msDFSR-Content'
+                'msDFSR-ContentSet'                    = 'top, msDFSR-ContentSet'
+                'msDFSR-GlobalSettings'                = 'top, msDFSR-GlobalSettings'
+                'msDFSR-LocalSettings'                 = 'top, msDFSR-LocalSettings'
+                'msDFSR-Member'                        = 'top, msDFSR-Member'
+                'msDFSR-ReplicationGroup'              = 'top, msDFSR-ReplicationGroup'
+                'msDFSR-Subscriber'                    = 'top, msDFSR-Subscriber'
+                'msDFSR-Subscription'                  = 'top, msDFSR-Subscription'
+                'msDFSR-Topology'                      = 'top, msDFSR-Topology'
+                'msDS-PasswordSettingsContainer'       = 'top, msDS-PasswordSettingsContainer'
+                'msDS-QuotaContainer'                  = 'top, msDS-QuotaContainer'
+                'msTPM-InformationObjectsContainer'    = 'top, msTPM-InformationObjectsContainer'
+                'organizationalUnit'                   = 'top, organizationalUnit'
+                'contact'                              = 'top, person, organizationalPerson, contact'
+                'user'                                 = 'top, person, organizationalPerson, user'
+                'computer'                             = 'top, person, organizationalPerson, user, computer'
+                'rIDManager'                           = 'top, rIDManager'
+                'rIDSet'                               = 'top, rIDSet'
+                'samServer'                            = 'top, securityObject, samServer'
+                'msExchSystemObjectsContainer'         = 'top, container, msExchSystemObjectsContainer'
+                'msRTCSIP-ApplicationContacts'         = 'top, container, msRTCSIP-ApplicationContacts'
+                'msRTCSIP-ArchivingServer'             = 'top, container, msRTCSIP-ArchivingServer'
+                'msRTCSIP-ConferenceDirectories'       = 'top, container, msRTCSIP-ConferenceDirectories'
+                'msRTCSIP-ConferenceDirectory'         = 'top, container, msRTCSIP-ConferenceDirectory'
+                'msRTCSIP-Domain'                      = 'top, container, msRTCSIP-Domain'
+                'msRTCSIP-EdgeProxy'                   = 'top, container, msRTCSIP-EdgeProxy'
+                'msRTCSIP-GlobalContainer'             = 'top, container, msRTCSIP-GlobalContainer'
+                'msRTCSIP-GlobalTopologySetting'       = 'top, container, msRTCSIP-GlobalTopologySetting'
+                'msRTCSIP-GlobalTopologySettings'      = 'top, container, msRTCSIP-GlobalTopologySettings'
+                'msRTCSIP-GlobalUserPolicy'            = 'top, container, msRTCSIP-GlobalUserPolicy'
+                'msRTCSIP-LocalNormalization'          = 'top, container, msRTCSIP-LocalNormalization'
+                'msRTCSIP-LocalNormalizations'         = 'top, container, msRTCSIP-LocalNormalizations'
+                'msRTCSIP-LocationContactMapping'      = 'top, container, msRTCSIP-LocationContactMapping'
+                'msRTCSIP-LocationContactMappings'     = 'top, container, msRTCSIP-LocationContactMappings'
+                'msRTCSIP-LocationProfile'             = 'top, container, msRTCSIP-LocationProfile'
+                'msRTCSIP-LocationProfiles'            = 'top, container, msRTCSIP-LocationProfiles'
+                'msRTCSIP-MCUFactories'                = 'top, container, msRTCSIP-MCUFactories'
+                'msRTCSIP-MCUFactory'                  = 'top, container, msRTCSIP-MCUFactory'
+                'msRTCSIP-MonitoringServer'            = 'top, container, msRTCSIP-MonitoringServer'
+                'msRTCSIP-PhoneRoute'                  = 'top, container, msRTCSIP-PhoneRoute'
+                'msRTCSIP-PhoneRoutes'                 = 'top, container, msRTCSIP-PhoneRoutes'
+                'msRTCSIP-Policies'                    = 'top, container, msRTCSIP-Policies'
+                'msRTCSIP-Pool'                        = 'top, container, msRTCSIP-Pool'
+                'msRTCSIP-Pools'                       = 'top, container, msRTCSIP-Pools'
+                'msRTCSIP-RouteUsage'                  = 'top, container, msRTCSIP-RouteUsage'
+                'msRTCSIP-RouteUsages'                 = 'top, container, msRTCSIP-RouteUsages'
+                'msRTCSIP-TrustedMCU'                  = 'top, container, msRTCSIP-TrustedMCU'
+                'msRTCSIP-TrustedMCUs'                 = 'top, container, msRTCSIP-TrustedMCUs'
+                'msRTCSIP-TrustedProxies'              = 'top, container, msRTCSIP-TrustedProxies'
+                'msRTCSIP-TrustedServer'               = 'top, container, msRTCSIP-TrustedServer'
+                'msRTCSIP-TrustedService'              = 'top, container, msRTCSIP-TrustedService'
+                'msRTCSIP-TrustedServices'             = 'top, container, msRTCSIP-TrustedServices'
+                'msRTCSIP-TrustedWebComponentsServer'  = 'top, container, msRTCSIP-TrustedWebComponentsServer'
+                'msRTCSIP-TrustedWebComponentsServers' = 'top, container, msRTCSIP-TrustedWebComponentsServers'
+                'msWMI-Som'                            = 'top, msWMI-Som'
+                'nTFRSReplicaSet'                      = 'top, nTFRSReplicaSet'
+                'packageRegistration'                  = 'top, packageRegistration'
+                'msDS-GroupManagedServiceAccount'      = 'top, person, organizationalPerson, user, computer, msDS-GroupManagedServiceAccount'
+                'pKIEnrollmentService'                 = 'top, pKIEnrollmentService'
+                'nTFRSSettings'                        = 'top, applicationSettings, nTFRSSettings'
+                'rpcServer'                            = 'top, leaf, connectionPoint, rpcEntry, rpcServer'
+                'rpcServerElement'                     = 'top, leaf, connectionPoint, rpcEntry, rpcServerElement'
+                'serviceConnectionPoint'               = 'top, leaf, connectionPoint, serviceConnectionPoint'
+                'msRTCSIP-ApplicationServerService'    = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-ApplicationServerService'
+                'msRTCSIP-MCUFactoryService'           = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-MCUFactoryService'
+                'msRTCSIP-PoolService'                 = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-PoolService'
+                'msRTCSIP-Service'                     = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-Service'
+                'msRTCSIP-WebComponentsService'        = 'top, leaf, connectionPoint, serviceConnectionPoint, msRTCSIP-WebComponentsService'
+                'pKICertificateTemplate'               = 'top, pKICertificateTemplate'
+                'certificationAuthority'               = 'top, certificationAuthority'
+                'msPKI-Enterprise-Oid'                 = 'top, msPKI-Enterprise-Oid'
             }
-            'objectClass' {
-                if ($objectClassMapping.ContainsKey($value)) {
-                    $formattedObjectClass = $objectClassMapping[$value]
-                } else {
-                    $formattedObjectClass = ($value -join ', ')
-                }
-                $outputLines.Add("$name`: $formattedObjectClass")
-                break
+
+            if ($null -eq $AdObject) {
+                Write-Error 'AdObject is null'
+                return
             }
-            default {
-                if ($isDateTime) {
-                    # Format date/time attributes in LDAP time format
-                    $formattedValue = '{0:yyyyMMddHHmmss.0Z}' -f $value.ToUniversalTime()
-                    $outputLines.Add("$name`: $formattedValue")
-                } elseif ($isByteArray) {
-                    # Base64 encode byte arrays
-                    if ($value.Length -gt 0) {
-                        $base64Value = [System.Convert]::ToBase64String($value)
-                        $outputLines.Add("$name`: $base64Value")
+
+            $outputLines = New-Object System.Collections.Generic.List[string]
+            $outputLines.Add('--------------------')
+
+            foreach ($property in $AdObject.PSObject.Properties) {
+                $name = $property.Name
+                $value = $property.Value
+
+                # Skip properties with empty values and unwanted properties
+                if ($null -eq $value -or ($value -is [string] -and [string]::IsNullOrWhiteSpace($value)) -or $ignoredValues -contains $name) {
+                    continue
+                }
+
+                # Cache type checks
+                $isDateTime = $value -is [datetime]
+                $isByteArray = $value -is [byte[]]
+                $isGuid = $value -is [guid]
+                $isCollection = $value -is [Microsoft.ActiveDirectory.Management.ADPropertyValueCollection]
+
+                switch ($name) {
+                    'nTSecurityDescriptor' {
+                        if ($null -ne $value) {
+                            $binaryForm = $value.GetSecurityDescriptorBinaryForm()
+                            if ($binaryForm.Length -gt 0) {
+                                $base64Value = [System.Convert]::ToBase64String($binaryForm)
+                                $outputLines.Add("$name`: $base64Value")
+                            }
+                        }
+                        break
                     }
-                } elseif ($isGuid) {
-                    $outputLines.Add("$name`: $value")
-                } elseif ($isCollection) {
-                    switch ($name) {
-                        'dSCorePropagationData' {
-                            # Efficiently find the latest date
-                            $latestDate = $null
-                            foreach ($date in $value) {
-                                if ($date -is [datetime]) {
-                                    if ($null -eq $latestDate -or $date -gt $latestDate) {
-                                        $latestDate = $date
+                    'objectClass' {
+                        if ($objectClassMapping.ContainsKey($value)) {
+                            $formattedObjectClass = $objectClassMapping[$value]
+                        }
+                        else {
+                            $formattedObjectClass = ($value -join ', ')
+                        }
+                        $outputLines.Add("$name`: $formattedObjectClass")
+                        break
+                    }
+                    default {
+                        if ($isDateTime) {
+                            # Format date/time attributes in LDAP time format
+                            $formattedValue = '{0:yyyyMMddHHmmss.0Z}' -f $value.ToUniversalTime()
+                            $outputLines.Add("$name`: $formattedValue")
+                        }
+                        elseif ($isByteArray) {
+                            # Base64 encode byte arrays
+                            if ($value.Length -gt 0) {
+                                $base64Value = [System.Convert]::ToBase64String($value)
+                                $outputLines.Add("$name`: $base64Value")
+                            }
+                        }
+                        elseif ($isGuid) {
+                            $outputLines.Add("$name`: $value")
+                        }
+                        elseif ($isCollection) {
+                            switch ($name) {
+                                'dSCorePropagationData' {
+                                    # Efficiently find the latest date
+                                    $latestDate = $null
+                                    foreach ($date in $value) {
+                                        if ($date -is [datetime]) {
+                                            if ($null -eq $latestDate -or $date -gt $latestDate) {
+                                                $latestDate = $date
+                                            }
+                                        }
                                     }
+                                    if ($null -ne $latestDate) {
+                                        $formattedDate = '{0:yyyyMMddHHmmss.0Z}' -f $latestDate.ToUniversalTime()
+                                        $outputLines.Add("$name`: $formattedDate")
+                                    }
+                                    break
+                                }
+                                'cACertificate' {
+                                    if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
+                                        $base64Value = [System.Convert]::ToBase64String($value[0])
+                                        $outputLines.Add("$name`: $base64Value")
+                                    }
+                                    break
+                                }
+                                'userCertificate' {
+                                    if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
+                                        $base64Value = [System.Convert]::ToBase64String($value[0])
+                                        $outputLines.Add("$name`: $base64Value")
+                                    }
+                                    break
+                                }
+                                'authorityRevocationList' {
+                                    $outputLines.Add("$name`: $null")
+                                    break
+                                }
+                                default {
+                                    $joinedValues = ($value | ForEach-Object { $_.ToString() }) -join ', '
+                                    $outputLines.Add("$name`: $joinedValues")
+                                    break
                                 }
                             }
-                            if ($null -ne $latestDate) {
-                                $formattedDate = '{0:yyyyMMddHHmmss.0Z}' -f $latestDate.ToUniversalTime()
-                                $outputLines.Add("$name`: $formattedDate")
-                            }
-                            break
                         }
-                        'cACertificate' {
-                            if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
-                                $base64Value = [System.Convert]::ToBase64String($value[0])
-                                $outputLines.Add("$name`: $base64Value")
-                            }
-                            break
+                        else {
+                            # General handling for other types
+                            $outputLines.Add("$name`: $value")
                         }
-                        'userCertificate' {
-                            if ($value.Count -gt 0 -and $value[0].Length -gt 0) {
-                                $base64Value = [System.Convert]::ToBase64String($value[0])
-                                $outputLines.Add("$name`: $base64Value")
-                            }
-                            break
-                        }
-                        'authorityRevocationList' {
-                            $outputLines.Add("$name`: $null")
-                            break
-                        }
-                        default {
-                            $joinedValues = ($value | ForEach-Object { $_.ToString() }) -join ', '
-                            $outputLines.Add("$name`: $joinedValues")
-                            break
-                        }
+                        break
                     }
-                } else {
-                    # General handling for other types
-                    $outputLines.Add("$name`: $value")
                 }
-                break
+            }
+
+            # Write the formatted content to the file using StreamWriter
+            foreach ($line in $outputLines) {
+                $StreamWriter.WriteLine($line)
             }
         }
-    }
 
-    # Write the formatted content to the file using StreamWriter
-    foreach ($line in $outputLines) {
-        $StreamWriter.WriteLine($line)
-    }
-}
+        function Perform-ADQuery {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [hashtable]$SearchParams,
 
-function Perform-ADQuery {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [hashtable]$SearchParams,
+                [Parameter(Mandatory = $true)]
+                [System.IO.StreamWriter]$StreamWriter,
 
-        [Parameter(Mandatory = $true)]
-        [System.IO.StreamWriter]$StreamWriter,
+                [Parameter(Mandatory = $true)]
+                [ref]$Count,
 
-        [Parameter(Mandatory = $true)]
-        [ref]$Count,
+                [Parameter(Mandatory = $false)]
+                [int]$PrintingThreshold = 1000
+            )
 
-        [Parameter(Mandatory = $false)]
-        [int]$PrintingThreshold = 1000
-    )
-
-    $SearchParams['ResultSetSize'] = 100000
+            $SearchParams['ResultSetSize'] = 100000
     
-    Get-ADObject @SearchParams | ForEach-Object {
-        Process-AdObject -AdObject $_ -StreamWriter $StreamWriter
-        $Count.Value++
-        if ($Count.Value % $PrintingThreshold -eq 0) {
-            Write-Output "      [**] Queried $($Count.Value) objects so far..."
+            Get-ADObject @SearchParams | ForEach-Object {
+                Process-AdObject -AdObject $_ -StreamWriter $StreamWriter
+                $Count.Value++
+                if ($Count.Value % $PrintingThreshold -eq 0) {
+                    Write-Output "      [**] Queried $($Count.Value) objects so far..."
+                }
+            }
+    
+            $StreamWriter.Flush()
         }
-    }
-    
-    $StreamWriter.Flush()
-}
 
-function Get-TopLevelContainers {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [hashtable]$Params
-    )
+        function Get-TopLevelContainers {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [hashtable]$Params
+            )
 
-    try {
-        $topLevelParams = $Params.Clone()
-        $topLevelParams['SearchScope'] = 'OneLevel'
-        $TopLevelContainers = Get-ADObject @topLevelParams 
-        return $TopLevelContainers
-    } catch {
-        Write-Error "Failed to retrieve top-level containers: $_"
-        return $null
-    }
-}
+            try {
+                $topLevelParams = $Params.Clone()
+                $topLevelParams['SearchScope'] = 'OneLevel'
+                $TopLevelContainers = Get-ADObject @topLevelParams 
+                return $TopLevelContainers
+            }
+            catch {
+                Write-Error "Failed to retrieve top-level containers: $_"
+                return $null
+            }
+        }
 
-function Initialize-StateFile {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]$Path,
+        function Initialize-StateFile {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [string]$Path,
 
-        [Parameter(Mandatory = $true)]
-        [string]$Output,
+                [Parameter(Mandatory = $true)]
+                [string]$Output,
 
-        [Parameter(Mandatory = $false)]
-        [string]$Server,
+                [Parameter(Mandatory = $false)]
+                [string]$Server,
 
-        [Parameter(Mandatory = $false)]
-        [string]$LdapFilter,
+                [Parameter(Mandatory = $false)]
+                [string]$LdapFilter,
 
-        [Parameter(Mandatory = $false)]
-        [string]$SearchBase,
+                [Parameter(Mandatory = $false)]
+                [string]$SearchBase,
 
-        [Parameter(Mandatory = $false)]
-        [bool]$SplitSearch = $false,
+                [Parameter(Mandatory = $false)]
+                [bool]$SplitSearch = $false,
 
-        [Parameter(Mandatory = $false)]
-        [bool]$LetterSplitSearch = $false
-    )
+                [Parameter(Mandatory = $false)]
+                [bool]$LetterSplitSearch = $false
+            )
 
-    # Determine execution mode
-    $mode = 'Standard'
-    if ($SplitSearch -and $LetterSplitSearch) {
-        $mode = 'SplitSearch+LetterSplitSearch'
-    } elseif ($SplitSearch) {
-        $mode = 'SplitSearch'
-    } elseif ($LetterSplitSearch) {
-        $mode = 'LetterSplitSearch'
-    }
+            # Determine execution mode
+            $mode = 'Standard'
+            if ($SplitSearch -and $LetterSplitSearch) {
+                $mode = 'SplitSearch+LetterSplitSearch'
+            }
+            elseif ($SplitSearch) {
+                $mode = 'SplitSearch'
+            }
+            elseif ($LetterSplitSearch) {
+                $mode = 'LetterSplitSearch'
+            }
 
-    $state = @{
-        version = '1.0'
-        toolMethod = 'ShadowHound-ADM'
-        timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-        outputFile = $Output
-        executionMode = $mode
-        ldapFilter = if ($LdapFilter) { $LdapFilter } else { '(objectGuid=*)' }
-        completedContainers = @()
-        completedLetters = @()
-        failedLetters = @{}
-        objectCount = 0
-    }
+            $state = @{
+                version             = '1.0'
+                toolMethod          = 'ShadowHound-ADM'
+                timestamp           = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+                outputFile          = $Output
+                executionMode       = $mode
+                ldapFilter          = if ($LdapFilter) { $LdapFilter } else { '(objectGuid=*)' }
+                completedContainers = @()
+                completedLetters    = @()
+                failedLetters       = @{}
+                objectCount         = 0
+            }
 
-    if ($Server) { $state.server = $Server }
-    if ($SearchBase) { $state.searchBase = $SearchBase }
+            if ($Server) { $state.server = $Server }
+            if ($SearchBase) { $state.searchBase = $SearchBase }
 
-    return $state
-}
+            return $state
+        }
 
-function Test-StateFileExists {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
+        function Test-StateFileExists {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [string]$Path
+            )
 
-    return (Test-Path -Path $Path -PathType Leaf)
-}
+            return (Test-Path -Path $Path -PathType Leaf)
+        }
 
-function Read-StateFile {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
+        function Read-StateFile {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [string]$Path
+            )
 
-    try {
-        $json = Get-Content -Path $Path -Raw -ErrorAction Stop
-        $psobject = $json | ConvertFrom-Json -ErrorAction Stop
+            try {
+                $json = Get-Content -Path $Path -Raw -ErrorAction Stop
+                $psobject = $json | ConvertFrom-Json -ErrorAction Stop
         
-        $state = @{}
-        $psobject.PSObject.Properties | ForEach-Object {
-            $name = $_.Name
-            $value = $_.Value
+                $state = @{}
+                $psobject.PSObject.Properties | ForEach-Object {
+                    $name = $_.Name
+                    $value = $_.Value
             
-            if ($value -is [PSCustomObject]) {
-                $nested = @{}
-                $value.PSObject.Properties | ForEach-Object {
-                    $nested[$_.Name] = $_.Value
+                    if ($value -is [PSCustomObject]) {
+                        $nested = @{}
+                        $value.PSObject.Properties | ForEach-Object {
+                            $nested[$_.Name] = $_.Value
+                        }
+                        $state[$name] = $nested
+                    }
+                    else {
+                        $state[$name] = $value
+                    }
                 }
-                $state[$name] = $nested
-            } else {
-                $state[$name] = $value
+        
+                return $state
+            }
+            catch {
+                return $null
             }
         }
+
+        function Write-StateFile {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [hashtable]$State,
+
+                [Parameter(Mandatory = $true)]
+                [string]$Path
+            )
+
+            try {
+                $State.timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+                $json = $State | ConvertTo-Json -Depth 10
         
-        return $state
-    } catch {
-        return $null
-    }
-}
+                try {
+                    $json = [regex]::Replace($json, '(?ms)("completedLetters"\s*:\s*\[)(.*?)(\])', {
+                            param($match)
+                            $prefix = $match.Groups[1].Value
+                            $content = $match.Groups[2].Value
+                            $suffix = $match.Groups[3].Value
+                            $compacted = $content -replace '\s+', ''
+                            "$prefix$compacted$suffix"
+                        })
+                }
+                catch {
+                    # Regex failed, use formatted JSON as-is
+                }
 
-function Write-StateFile {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [hashtable]$State,
+                $json | Set-Content -Path $Path -Force -ErrorAction Stop
+            }
+            catch {
+                Write-Error "[-] Failed to write state file: $_"
+            }
+        }
 
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
+        function Remove-StateFile {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                [string]$Path
+            )
 
-    try {
-        $State.timestamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-        $json = $State | ConvertTo-Json -Depth 10
+            if (Test-Path -Path $Path) {
+                try {
+                    Remove-Item -Path $Path -Force -ErrorAction Stop
+                }
+                catch {
+                    Write-Error "[-] Failed to remove state file: $_"
+                }
+            }
+        }
+
+        function Show-StatePrompt {
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory = $true)]
+                $State,
+
+                [Parameter(Mandatory = $true)]
+                [string]$Path,
+
+                [Parameter(Mandatory = $false)]
+                [switch]$NonInteractive
+            )
+
+            [Console]::WriteLine('')
+            [Console]::WriteLine('[*] Found existing state file: ' + $Path)
+            [Console]::WriteLine('[*] Last checkpoint:')
+    
+            $containers = $State['completedContainers']
+            if ($containers -and $containers.Count -gt 0) {
+                [Console]::WriteLine("    - Completed containers: $($containers.Count)")
+            }
+    
+            $currentContainer = $State['currentContainer']
+            if ($currentContainer) {
+                [Console]::WriteLine("    - Current container: $currentContainer")
+            }
+    
+            $letters = $State['completedLetters']
+            if ($letters -and $letters.Count -gt 0) {
+                $letterList = $letters -join ', '
+                if ($currentContainer) {
+                    [Console]::WriteLine("    - Completed letters (in current container): $letterList")
+                }
+                else {
+                    [Console]::WriteLine("    - Completed letters: $letterList")
+                }
+            }
+            elseif ($currentContainer) {
+                [Console]::WriteLine('    - Completed letters (in current container): (none yet)')
+            }
+            else {
+                [Console]::WriteLine('    - Completed letters: (none yet)')
+            }
+    
+            $objCount = $State['objectCount']
+            if ($objCount -and $objCount -gt 0) {
+                [Console]::WriteLine("    - Objects enumerated: $objCount")
+            }
+    
+            $failedLetters = $State['failedLetters']
+            if ($failedLetters -and $failedLetters.Count -gt 0) {
+                [Console]::WriteLine('')
+                [Console]::WriteLine('[!] Failed letters detected (will be retried on resume):')
+                foreach ($container in $failedLetters.Keys) {
+                    $letters = $failedLetters[$container] -join ', '
+                    [Console]::WriteLine("    Container: $container")
+                    [Console]::WriteLine("    Letters: $letters")
+                }
+            }
+    
+            $timestamp = $State['timestamp']
+            if ($timestamp) {
+                [Console]::WriteLine("    - Timestamp: $timestamp")
+            }
+    
+            [Console]::WriteLine('')
+            [Console]::WriteLine('[!] Note: Resuming will append to existing output file')
+            [Console]::WriteLine('')
+
+            if ($NonInteractive) {
+                [Console]::WriteLine('[*] Non-interactive mode: Auto-resuming...')
+                return 'Y'
+            }
+
+            while ($true) {
+                $choice = Read-Host '[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel'
+                $choice = $choice.Trim().ToUpper()
         
-        try {
-            $json = [regex]::Replace($json, '(?ms)\[(\s*"[^"]*"\s*(?:,\s*"[^"]*"\s*)*)\]', {
-                param($match)
-                $content = $match.Groups[1].Value
-                $compacted = $content -replace '\s+', ''
-                "[$compacted]"
-            })
-        } catch {
-            # Regex failed, use formatted JSON as-is
-        }
-        
-        $json | Set-Content -Path $Path -Force -ErrorAction Stop
-    } catch {
-        Write-Error "[-] Failed to write state file: $_"
-    }
-}
-
-function Remove-StateFile {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    if (Test-Path -Path $Path) {
-        try {
-            Remove-Item -Path $Path -Force -ErrorAction Stop
-        } catch {
-            Write-Error "[-] Failed to remove state file: $_"
+                if ($choice -eq 'Y' -or $choice -eq 'YES') {
+                    [Console]::WriteLine('[+] Resuming from checkpoint...')
+                    return 'Y'
+                }
+                elseif ($choice -eq 'N' -or $choice -eq 'NO') {
+                    [Console]::WriteLine('[+] Starting fresh enumeration...')
+                    return 'N'
+                }
+                elseif ($choice -eq 'C' -or $choice -eq 'CANCEL') {
+                    [Console]::WriteLine('[-] Cancelled by user')
+                    return 'C'
+                }
+                else {
+                    [Console]::WriteLine('[!] Invalid input. Please enter Y, N, or C.')
+                }
+            }
         }
     }
-}
-
-function Show-StatePrompt {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        $State,
-
-        [Parameter(Mandatory = $true)]
-        [string]$Path
-    )
-
-    [Console]::WriteLine('')
-    [Console]::WriteLine('[*] Found existing state file: ' + $Path)
-    [Console]::WriteLine('[*] Last checkpoint:')
-    
-    $containers = $State['completedContainers']
-    if ($containers -and $containers.Count -gt 0) {
-        [Console]::WriteLine("    - Completed containers: $($containers.Count)")
-    }
-    
-    $currentContainer = $State['currentContainer']
-    if ($currentContainer) {
-        [Console]::WriteLine("    - Current container: $currentContainer")
-    }
-    
-    $letters = $State['completedLetters']
-    if ($letters -and $letters.Count -gt 0) {
-        $letterList = $letters -join ', '
-        if ($currentContainer) {
-            [Console]::WriteLine("    - Completed letters (in current container): $letterList")
-        } else {
-            [Console]::WriteLine("    - Completed letters: $letterList")
-        }
-    } elseif ($currentContainer) {
-        [Console]::WriteLine('    - Completed letters (in current container): (none yet)')
-    } else {
-        [Console]::WriteLine('    - Completed letters: (none yet)')
-    }
-    
-    $objCount = $State['objectCount']
-    if ($objCount -and $objCount -gt 0) {
-        [Console]::WriteLine("    - Objects enumerated: $objCount")
-    }
-    
-    $failedLetters = $State['failedLetters']
-    if ($failedLetters -and $failedLetters.Count -gt 0) {
-        [Console]::WriteLine('')
-        [Console]::WriteLine('[!] Failed letters detected (will be retried on resume):')
-        foreach ($container in $failedLetters.Keys) {
-            $letters = $failedLetters[$container] -join ', '
-            [Console]::WriteLine("    Container: $container")
-            [Console]::WriteLine("    Letters: $letters")
-        }
-    }
-    
-    $timestamp = $State['timestamp']
-    if ($timestamp) {
-        [Console]::WriteLine("    - Timestamp: $timestamp")
-    }
-    
-    [Console]::WriteLine('')
-    [Console]::WriteLine('[!] Note: Resuming will append to existing output file')
-    [Console]::WriteLine('')
-
-    while ($true) {
-        $choice = Read-Host '[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel'
-        $choice = $choice.Trim().ToUpper()
-        
-        if ($choice -eq 'Y' -or $choice -eq 'YES') {
-            [Console]::WriteLine('[+] Resuming from checkpoint...')
-            return 'Y'
-        } elseif ($choice -eq 'N' -or $choice -eq 'NO') {
-            [Console]::WriteLine('[+] Starting fresh enumeration...')
-            return 'N'
-        } elseif ($choice -eq 'C' -or $choice -eq 'CANCEL') {
-            [Console]::WriteLine('[-] Cancelled by user')
-            return 'C'
-        } else {
-            [Console]::WriteLine('[!] Invalid input. Please enter Y, N, or C.')
-        }
-    }
-}

--- a/split_output.py
+++ b/split_output.py
@@ -61,7 +61,7 @@ def split_large_file_into_chunks(input_file, base_output_name, num_chunks):
 
 
 def write_chunk_to_file(chunk_lines, base_output_name, chunk_index, chunk_object_count):
-    output_file = f"{base_output_name}_chunk_{chunk_index}.txt"
+    output_file = f"{base_output_name}_chunk_{chunk_index}.log"
     with open(output_file, "w", encoding="utf-8-sig") as outfile:
         # Write the starting delimiter
         outfile.write(f"{object_delimiter}\n{object_delimiter}\n")


### PR DESCRIPTION

## What This Adds

Two features that make enumerating big AD environments actually practical:

1. **Resumable Enumeration** - Checkpoint system that saves progress. Get interrupted? Just run it again, picks up where it left off.
2. **3-Letter Splitting** - When 2-letter prefixes fail with timeout errors or "invalid enumeration context", the current behavior is to skip it, and lose objects. So here it'll automatically split to 3-letter prefixes using **batched queries**.
---

## Resumable Enumeration

Enumeration can take hours in large domains. Network drops, accidental Ctrl+C, or killing the session means starting over. from my exprience -> it's a nightmare.

### How it works

State file auto-created at `<output>.state.json` tracking:
- Which letters/containers were completed
- Which ones failed (to retry)

**Example:**
```powershell
# Start enumeration
ShadowHound-ADM -Server 10.10.10.10 -OutputFilePath output.txt -LetterSplitSearch

# Gets interrupted at letter 'f'...

# Run same command again - resume prompt appears
ShadowHound-ADM -Server 10.10.10.10 -OutputFilePath output.txt -LetterSplitSearch
```

**Resume prompt:**
```
[*] Found existing state file: C:\Tools\ShadowHound\output.txt.state.json
[*] Last checkpoint:
    - Current container: OU=Users,DC=corp,DC=local
    - Completed letters: a, b, c, d, e

[!] Note: Resuming will append to existing output file

[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel: 
```

**State file example:**
```json
{
    "outputFile":  "C:\\Tools\\ShadowHound\\output.txt",
    "completedContainers":  [],
    "executionMode":  "LetterSplitSearch",
    "server":  "10.10.10.10",
    "currentContainer": "OU=Users,DC=corp,DC=local",
    "completedLetters":  ["a", "b", "c", "d", "e"],
    "version":  "1.0",
    "failedLetters":  {},
    "ldapFilter":  "(ObjectGuid=*)",
    "objectCount":  3000,
    "searchBase":  "OU=Users,DC=corp,DC=local",
    "toolMethod":  "ShadowHound-ADM",
    "timestamp":  "2025-12-16T22:17:58Z"
}

```

### New Flags

- `-StateFile <path>` - Custom state file location (default: `<output>.state.json`)
- `-StartFromLetter <char>` - Skip ahead to specific letter (`"m"` or `"t5"`)
- `-DisableStateFile` - Don't create any state file automatically
- `-KeepStateFile` - Don't auto-delete state file on completion

**Examples:**
```powershell
# No artifacts left behind
ShadowHound-ADM -OutputFilePath output.txt -LetterSplitSearch -DisableStateFile

# Start from letter 'm' (skip a-l)
ShadowHound-ADM -OutputFilePath output.txt -LetterSplitSearch -StartFromLetter "m"

# Custom state file location  
ShadowHound-ADM -OutputFilePath output.txt -LetterSplitSearch -StateFile "C:\temp\state.json"
```

---

## 3-Letter Splitting for Dense Prefixes

### The Problem

Original tool already handles ADWS timeouts by splitting 1-letter to 2-letter:

```
[*] Querying for objects with CN starting with 'f'
[-] Failed to process (CN=f*): invalid enumeration context  
    Trying to split each letter again...
[*] Querying for objects with CN starting with 'fa'
[*] Querying for objects with CN starting with 'fb'
...
```

But what if `fb*` also times out?

**Before this PR:**
("fb" will be skipped - losing data!)
```
[-] Failed to process (CN=fb*): The server has returned the following error: invalid enumeration context.
     Moving to the next sub letter...
[*] Querying for objects with CN starting with 'fc'
     [**] Queried 95000 objects so far...
```

**After this PR:**
(Batch - group of 4 of 3-letters to speed up things)
```
[-] Failed to process (CN=fb*): The server has returned the following error: invalid enumeration context.
     Trying to split to 3-letter prefixes...
[*] Querying batch: fba, fbb, fbc, fbd
      [**] Queried 95000 objects so far...
[*] Querying batch: fbe, fbf, fbg, fbh
[*] Querying batch: fbi, fbj, fbk, fbl
....
[+] All 3-letter prefixes completed
```

### Batched Queries - How it looks

Instead of 46 separate queries (one per character), batches 4 prefixes using LDAP OR:

```ldap
(&(objectGuid=*)(|(cn=fba*)(cn=fbb*)(cn=fbc*)(cn=fbd*)))
```
### If a batch fails, it retries each 3-letter prefix individually.
Failed again? will be saved in the state file.
```json
"failedLetters":  {
                          "global":  [
                                         "bdc",
                                         "cdc",
                                         "ddc",
                                         "hdc"
                                     ]
                      },
```