### PR TITLE
Resumable Enumeration and 3-Letter Splitting to ShadowHound-ADM

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,6 @@ For large JSON files (>100MB), consider splitting them with tools like [ShredHou
 - **Yehuda Smirnov**
   - Twitter: [@yudasm_](https://twitter.com/yudasm_)
   - BlueSky: [@yudasm.bsky.social](https://bsky.app/profile/yudasm.bsky.social)
+ 
+## Contributors
+- [DrorDvash](https://github.com/DrorDvash) - For Resumable Enumeration and 3-Letter Splitting [PR#6](https://github.com/Friends-Security/ShadowHound/pull/6) 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ ShadowHound-ADM -OutputFilePath "C:\Results\ldap_output.txt" -SplitSearch -Lette
 
 ### Resumable Enumeration (ShadowHound-ADM.ps1)
 
-Enumeration automatically saves progress. If interrupted (network drop, Ctrl+C, session killed), just run the same command again - it picks up where it left off.
+Enumeration automatically saves ogress. If interrupted (network drop, Ctrl+C, session killed), just run the same command again - it picks up where it left off.
 
 ```powershell
 # Start enumeration
@@ -104,10 +104,10 @@ ShadowHound-ADM -Server dc.corp.local -OutputFilePath output.txt -LetterSplitSea
 **New parameters:**
 - **`-DisableStateFile`**: No checkpoints (OPSEC - no artifacts)
 - **`-StartFromLetter <char>`**: Skip ahead (e.g. `-StartFromLetter "m"`)
-- **`-KeepStateFile`**: Preserve state file after completion
+- **`-KeepStateFile`**: eserve state file after completion
 - **`-StateFile <path>`**: Custom state file location
 
-For more details on resumable enumeration and 3-letter splitting, see the [feature PR](https://github.com/Friends-Security/ShadowHound/pull/4).
+For more details on resumable enumeration and 3-letter splitting, see the [feature PR](https://github.com/Friends-Security/ShadowHound/pull/6).
 
 ## Converting Data for BloodHound
 

--- a/ShadowHound-ADM.ps1
+++ b/ShadowHound-ADM.ps1
@@ -343,11 +343,18 @@ function ShadowHound-ADM {
                     continue
                 }
                 
-                # Skip already completed containers from state file
+                # Skip already completed containers from state file (unless they have failed letters)
                 if ($stateEnabled -and $stateData -and $stateData.completedContainers -contains $containerDN) {
-                    Write-Output "[+] Container $containerDN already completed, skipping..."
-                    $processedContainers += $containerDN
-                    continue
+                    # Check if this container has failed letters that need retry
+                    $hasFailedLetters = $stateData.failedLetters -and $stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN].Count -gt 0
+                    if (-not $hasFailedLetters) {
+                        Write-Output "[+] Container $containerDN already completed, skipping..."
+                        $processedContainers += $containerDN
+                        continue
+                    }
+                    else {
+                        Write-Output "[*] Container $containerDN has failed letters to retry..."
+                    }
                 }
 
                 # Check if this container is being retried from a previous failure
@@ -406,7 +413,159 @@ function ShadowHound-ADM {
                     # Full charset for 2-letter and 3-letter splits includes . and - for edge cases
                     $charsetFull = $charset + '.', '-'
                     $OriginalFilter = $containerSearchParams['LdapFilter']
+
+                    # Check if this container has failed letters to retry (from previous run)
+                    $failedLettersForContainer = @()
+                    if ($stateEnabled -and $stateData -and $stateData.failedLetters -and $stateData.failedLetters.ContainsKey($containerDN)) {
+                        $failedLettersForContainer = @($stateData.failedLetters[$containerDN])
+                    }
+
+                    # If we have failed letters, ONLY retry those - don't process all letters again
+                    if ($failedLettersForContainer.Count -gt 0) {
+                        Write-Output "  [*] Retrying $($failedLettersForContainer.Count) failed letter(s): $($failedLettersForContainer -join ', ')"
+
+                        foreach ($failedLetter in $failedLettersForContainer) {
+                            Write-Output "  [*] Retrying failed letter '$failedLetter' for $containerDN"
+
+                            try {
+                                $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$failedLetter*))"
+                                Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+
+                                # Success - remove from failed letters
+                                if ($stateEnabled -and $stateData) {
+                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $failedLetter })
+                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                        $stateData.failedLetters.Remove($containerDN)
+                                    }
+                                    $stateData.objectCount = $count.Value
+                                    Write-StateFile -State $stateData -Path $statePath
+                                }
+                            }
+                            catch {
+                                Write-Output "   [-] Failed to process (CN=$failedLetter*) for container '$containerDN': $_"
+                                Write-Output '       Trying to split to 3-letter prefixes...'
+
+                                $batchSize = 4
+                                $tripleSuccess = $false
+                                $failedBatches = @()
+
+                                for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                    $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                    $batch = $charsetFull[$batchIdx..$batchEnd]
+
+                                    $orFilters = @()
+                                    foreach ($tripleChar in $batch) {
+                                        $triplePrefix = "$failedLetter$tripleChar"
+                                        $orFilters += "(cn=$triplePrefix*)"
+                                    }
+
+                                    $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                    $batchNames = ($batch | ForEach-Object { "$failedLetter$_" }) -join ', '
+
+                                    try {
+                                        Write-Output "    [*] Querying batch: $batchNames"
+                                        $containerSearchParams['LdapFilter'] = $batchFilter
+                                        Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                        $tripleSuccess = $true
+
+                                        if ($stateEnabled -and $stateData) {
+                                            foreach ($tripleChar in $batch) {
+                                                $triplePrefix = "$failedLetter$tripleChar"
+                                                if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $triplePrefix) {
+                                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $triplePrefix })
+                                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                        $stateData.failedLetters.Remove($containerDN)
+                                                    }
+                                                }
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    }
+                                    catch {
+                                        Write-Output "    [-] Batch failed - will retry individually"
+                                        if ($stateEnabled -and $stateData) {
+                                            if (-not $stateData.failedLetters[$containerDN]) {
+                                                $stateData.failedLetters[$containerDN] = @()
+                                            }
+                                            foreach ($tripleChar in $batch) {
+                                                $triplePrefix = "$failedLetter$tripleChar"
+                                                if ($stateData.failedLetters[$containerDN] -notcontains $triplePrefix) {
+                                                    $stateData.failedLetters[$containerDN] += $triplePrefix
+                                                }
+                                            }
+                                            $stateData.objectCount = $count.Value
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                        $failedBatches += , @($batch)
+                                    }
+                                }
+
+                                foreach ($batch in $failedBatches) {
+                                    foreach ($tripleChar in $batch) {
+                                        $triplePrefix = "$failedLetter$tripleChar"
+                                        try {
+                                            Write-Output "    [*] Querying $containerDN for CN starting with '$triplePrefix'"
+                                            $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                            $tripleSuccess = $true
+
+                                            if ($stateEnabled -and $stateData) {
+                                                if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $triplePrefix) {
+                                                    $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $triplePrefix })
+                                                    if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                        $stateData.failedLetters.Remove($containerDN)
+                                                    }
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                        }
+                                        catch {
+                                            Write-Output "    [-] Failed to process (CN=$triplePrefix*): $_"
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not $stateData.failedLetters[$containerDN]) {
+                                                    $stateData.failedLetters[$containerDN] = @()
+                                                }
+                                                if ($stateData.failedLetters[$containerDN] -notcontains $triplePrefix) {
+                                                    $stateData.failedLetters[$containerDN] += $triplePrefix
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                            continue
+                                        }
+                                    }
+                                }
+
+                                # Remove 2-letter from failed if 3-letter succeeded
+                                if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                    if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $failedLetter) {
+                                        $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $failedLetter })
+                                        if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                            $stateData.failedLetters.Remove($containerDN)
+                                        }
+                                        Write-StateFile -State $stateData -Path $statePath
+                                    }
+                                }
+                            }
+                        }
+
+                        # After retrying failed letters, mark container complete if no failures remain
+                        $processedContainers += $containerDN
+                        $isFirstContainer = $false
+
+                        if ($stateEnabled -and $stateData) {
+                            $stillHasFailedLetters = $stateData.failedLetters -and $stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN].Count -gt 0
+                            if (-not $stillHasFailedLetters -and -not ($stateData.completedContainers -contains $containerDN)) {
+                                $stateData.completedContainers += $containerDN
+                            }
+                            Write-StateFile -State $stateData -Path $statePath
+                        }
+                        continue
+                    }
                     
+                    # Normal processing - no failed letters to retry
                     # Determine starting letter for this container
                     $startIdx = 0
                     if ($stateEnabled -and $stateData -and $stateData.currentContainer -eq $containerDN -and $stateData.completedLetters) {
@@ -502,10 +661,121 @@ function ShadowHound-ADM {
                                     }
                                 }
                                 catch {
-                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
-                                    
-                                    # Track failed letter for this container
-                                    if ($stateEnabled -and $stateData) {
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_"
+                                    Write-Output '       Trying to split to 3-letter prefixes...'
+
+                                    $batchSize = 4
+                                    $tripleSuccess = $false
+                                    $failedBatches = @()
+
+                                    for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                        $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                        $batch = $charsetFull[$batchIdx..$batchEnd]
+
+                                        $orFilters = @()
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            $orFilters += "(cn=$triplePrefix*)"
+                                        }
+
+                                        $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                        $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+
+                                        try {
+                                            Write-Output "    [*] Querying batch: $batchNames"
+                                            $containerSearchParams['LdapFilter'] = $batchFilter
+                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                            $tripleSuccess = $true
+
+                                            if ($stateEnabled -and $stateData) {
+                                                foreach ($tripleChar in $batch) {
+                                                    $triplePrefix = "$doubleChar$tripleChar"
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $triplePrefix })
+                                                        if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                            $stateData.failedLetters.Remove($containerDN)
+                                                        }
+                                                    }
+                                                }
+                                                $stateData.currentContainer = $containerDN
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                        }
+                                        catch {
+                                            Write-Output "    [-] Batch failed - will retry individually"
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not $stateData.failedLetters[$containerDN]) {
+                                                    $stateData.failedLetters[$containerDN] = @()
+                                                }
+                                                foreach ($tripleChar in $batch) {
+                                                    $triplePrefix = "$doubleChar$tripleChar"
+                                                    if ($stateData.failedLetters[$containerDN] -notcontains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] += $triplePrefix
+                                                    }
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                            $failedBatches += , @($batch)
+                                        }
+                                    }
+
+                                    foreach ($batch in $failedBatches) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            try {
+                                                Write-Output "    [*] Querying $containerDN for CN starting with '$triplePrefix'"
+                                                $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                                Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                                $tripleSuccess = $true
+
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $triplePrefix })
+                                                        if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                            $stateData.failedLetters.Remove($containerDN)
+                                                        }
+                                                    }
+                                                    $stateData.currentContainer = $containerDN
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                            }
+                                            catch {
+                                                Write-Output "    [-] Failed to process (CN=$triplePrefix*): $_"
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not $stateData.failedLetters[$containerDN]) {
+                                                        $stateData.failedLetters[$containerDN] = @()
+                                                    }
+                                                    if ($stateData.failedLetters[$containerDN] -notcontains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] += $triplePrefix
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                                continue
+                                            }
+                                        }
+                                    }
+
+                                    # Remove 2-letter from failed if 3-letter succeeded
+                                    if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($containerDN)
+                                            }
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    }
+                                    elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
                                         if (-not $stateData.failedLetters[$containerDN]) {
                                             $stateData.failedLetters[$containerDN] = @()
                                         }
@@ -520,7 +790,7 @@ function ShadowHound-ADM {
                             }
                             continue
                         }
-                        
+
                         Write-Output "  [*] Querying $containerDN for objects with CN starting with '$charStr'"
                         $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$charStr*))"
 
@@ -576,10 +846,121 @@ function ShadowHound-ADM {
                                     }
                                 }
                                 catch {
-                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_`nMoving to the next sub letter..."
-                                    
-                                    # Track failed letter for this container
-                                    if ($stateEnabled -and $stateData) {
+                                    Write-Output "   [-] Failed to process (CN=$doubleChar*) for container '$containerDN': $_"
+                                    Write-Output '       Trying to split to 3-letter prefixes...'
+
+                                    $batchSize = 4
+                                    $tripleSuccess = $false
+                                    $failedBatches = @()
+
+                                    for ($batchIdx = 0; $batchIdx -lt $charsetFull.Length; $batchIdx += $batchSize) {
+                                        $batchEnd = [Math]::Min($batchIdx + $batchSize - 1, $charsetFull.Length - 1)
+                                        $batch = $charsetFull[$batchIdx..$batchEnd]
+
+                                        $orFilters = @()
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            $orFilters += "(cn=$triplePrefix*)"
+                                        }
+
+                                        $batchFilter = "(&$OriginalFilter(|$($orFilters -join '')))"
+                                        $batchNames = ($batch | ForEach-Object { "$doubleChar$_" }) -join ', '
+
+                                        try {
+                                            Write-Output "    [*] Querying batch: $batchNames"
+                                            $containerSearchParams['LdapFilter'] = $batchFilter
+                                            Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                            $tripleSuccess = $true
+
+                                            if ($stateEnabled -and $stateData) {
+                                                foreach ($tripleChar in $batch) {
+                                                    $triplePrefix = "$doubleChar$tripleChar"
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $triplePrefix })
+                                                        if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                            $stateData.failedLetters.Remove($containerDN)
+                                                        }
+                                                    }
+                                                }
+                                                $stateData.currentContainer = $containerDN
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                        }
+                                        catch {
+                                            Write-Output "    [-] Batch failed - will retry individually"
+                                            if ($stateEnabled -and $stateData) {
+                                                if (-not $stateData.failedLetters[$containerDN]) {
+                                                    $stateData.failedLetters[$containerDN] = @()
+                                                }
+                                                foreach ($tripleChar in $batch) {
+                                                    $triplePrefix = "$doubleChar$tripleChar"
+                                                    if ($stateData.failedLetters[$containerDN] -notcontains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] += $triplePrefix
+                                                    }
+                                                }
+                                                $stateData.objectCount = $count.Value
+                                                Write-StateFile -State $stateData -Path $statePath
+                                            }
+                                            $failedBatches += , @($batch)
+                                        }
+                                    }
+
+                                    foreach ($batch in $failedBatches) {
+                                        foreach ($tripleChar in $batch) {
+                                            $triplePrefix = "$doubleChar$tripleChar"
+                                            try {
+                                                Write-Output "    [*] Querying $containerDN for CN starting with '$triplePrefix'"
+                                                $containerSearchParams['LdapFilter'] = "(&$OriginalFilter(cn=$triplePrefix*))"
+                                                Perform-ADQuery -SearchParams $containerSearchParams -StreamWriter $streamWriter -Count $count -PrintingThreshold $printingThreshold
+                                                $tripleSuccess = $true
+
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not ($stateData.completedLetters -contains $triplePrefix)) {
+                                                        $stateData.completedLetters += $triplePrefix
+                                                    }
+                                                    if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $triplePrefix })
+                                                        if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                            $stateData.failedLetters.Remove($containerDN)
+                                                        }
+                                                    }
+                                                    $stateData.currentContainer = $containerDN
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                            }
+                                            catch {
+                                                Write-Output "    [-] Failed to process (CN=$triplePrefix*): $_"
+                                                if ($stateEnabled -and $stateData) {
+                                                    if (-not $stateData.failedLetters[$containerDN]) {
+                                                        $stateData.failedLetters[$containerDN] = @()
+                                                    }
+                                                    if ($stateData.failedLetters[$containerDN] -notcontains $triplePrefix) {
+                                                        $stateData.failedLetters[$containerDN] += $triplePrefix
+                                                    }
+                                                    $stateData.objectCount = $count.Value
+                                                    Write-StateFile -State $stateData -Path $statePath
+                                                }
+                                                continue
+                                            }
+                                        }
+                                    }
+
+                                    # Remove 2-letter from failed if 3-letter succeeded
+                                    if ($tripleSuccess -and $stateEnabled -and $stateData) {
+                                        if ($stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN] -contains $doubleChar) {
+                                            $stateData.failedLetters[$containerDN] = @($stateData.failedLetters[$containerDN] | Where-Object { $_ -ne $doubleChar })
+                                            if ($stateData.failedLetters[$containerDN].Count -eq 0) {
+                                                $stateData.failedLetters.Remove($containerDN)
+                                            }
+                                            Write-StateFile -State $stateData -Path $statePath
+                                        }
+                                    }
+                                    elseif (-not $tripleSuccess -and $stateEnabled -and $stateData) {
                                         if (-not $stateData.failedLetters[$containerDN]) {
                                             $stateData.failedLetters[$containerDN] = @()
                                         }
@@ -597,9 +978,13 @@ function ShadowHound-ADM {
 
                     $processedContainers += $containerDN
                     $isFirstContainer = $false
-                    
+
+                    # Only mark container as completed if it has no failed letters
                     if ($stateEnabled -and $stateData) {
-                        $stateData.completedContainers += $containerDN
+                        $hasFailedLettersForContainer = $stateData.failedLetters -and $stateData.failedLetters.ContainsKey($containerDN) -and $stateData.failedLetters[$containerDN].Count -gt 0
+                        if (-not $hasFailedLettersForContainer -and -not ($stateData.completedContainers -contains $containerDN)) {
+                            $stateData.completedContainers += $containerDN
+                        }
                         $stateData.completedLetters = @()
                         $stateData.currentContainer = $null
                         Write-StateFile -State $stateData -Path $statePath


### PR DESCRIPTION
## What This Adds

Two features that make enumerating big AD environments actually practical:

1. **Resumable Enumeration** - Checkpoint system that saves progress. Get interrupted? Just run it again, picks up where it left off.
2. **3-Letter Splitting** - When 2-letter prefixes fail with timeout errors or "invalid enumeration context", the current behavior is to skip it, and lose objects. So here it'll automatically split to 3-letter prefixes using **batched queries**.
---

## Resumable Enumeration

Enumeration can take hours in large domains. Network drops, accidental Ctrl+C, or killing the session means starting over. from my exprience -> it's a nightmare.

### How it works

State file auto-created at `<output>.state.json` tracking:
- Which letters/containers were completed
- Which ones failed (to retry)

**Example:**
```powershell
# Start enumeration
ShadowHound-ADM -Server 10.10.10.10 -OutputFilePath output.txt -LetterSplitSearch

# Gets interrupted at letter 'f'...

# Run same command again - resume prompt appears
ShadowHound-ADM -Server 10.10.10.10 -OutputFilePath output.txt -LetterSplitSearch
```

**Resume prompt:**
```
[*] Found existing state file: C:\Tools\ShadowHound\output.txt.state.json
[*] Last checkpoint:
    - Current container: OU=Users,DC=corp,DC=local
    - Completed letters: a, b, c, d, e

[!] Note: Resuming will append to existing output file

[?] Resume from checkpoint? [Y]es, [N]o, [C]ancel: 
```

**State file example:**
```json
{
    "outputFile":  "C:\\Tools\\ShadowHound\\output.txt",
    "completedContainers":  [],
    "executionMode":  "LetterSplitSearch",
    "server":  "10.10.10.10",
    "currentContainer": "OU=Users,DC=corp,DC=local",
    "completedLetters":  ["a", "b", "c", "d", "e"],
    "version":  "1.0",
    "failedLetters":  {},
    "ldapFilter":  "(ObjectGuid=*)",
    "objectCount":  3000,
    "searchBase":  "OU=Users,DC=corp,DC=local",
    "toolMethod":  "ShadowHound-ADM",
    "timestamp":  "2025-12-16T22:17:58Z"
}

```

### New Flags

- `-StateFile <path>` - Custom state file location (default: `<output>.state.json`)
- `-StartFromLetter <char>` - Skip ahead to specific letter (`"m"` or `"t5"`)
- `-DisableStateFile` - Don't create any state file automatically
- `-KeepStateFile` - Don't auto-delete state file on completion

**Examples:**
```powershell
# No artifacts left behind
ShadowHound-ADM -OutputFilePath output.txt -LetterSplitSearch -DisableStateFile

# Start from letter 'm' (skip a-l)
ShadowHound-ADM -OutputFilePath output.txt -LetterSplitSearch -StartFromLetter "m"

# Custom state file location  
ShadowHound-ADM -OutputFilePath output.txt -LetterSplitSearch -StateFile "C:\temp\state.json"
```

---

## 3-Letter Splitting for Dense Prefixes

### The Problem

Original tool already handles ADWS timeouts by splitting 1-letter to 2-letter:

```
[*] Querying for objects with CN starting with 'f'
[-] Failed to process (CN=f*): invalid enumeration context  
    Trying to split each letter again...
[*] Querying for objects with CN starting with 'fa'
[*] Querying for objects with CN starting with 'fb'
...
```

But what if `fb*` also times out?

**Before this PR:**
("fb" will be skipped - losing data!)
```
[-] Failed to process (CN=fb*): The server has returned the following error: invalid enumeration context.
     Moving to the next sub letter...
[*] Querying for objects with CN starting with 'fc'
     [**] Queried 95000 objects so far...
```

**After this PR:**
(Batch - group of 4 of 3-letters to speed up things)
```
[-] Failed to process (CN=fb*): The server has returned the following error: invalid enumeration context.
     Trying to split to 3-letter prefixes...
[*] Querying batch: fba, fbb, fbc, fbd
      [**] Queried 95000 objects so far...
[*] Querying batch: fbe, fbf, fbg, fbh
[*] Querying batch: fbi, fbj, fbk, fbl
....
[+] All 3-letter prefixes completed
```

### Batched Queries - How it looks

Instead of 46 separate queries (one per character), batches 4 prefixes using LDAP OR:

```ldap
(&(objectGuid=*)(|(cn=fba*)(cn=fbb*)(cn=fbc*)(cn=fbd*)))
```
### If a batch fails, it retries each 3-letter prefix individually.
Failed again? will be saved in the state file.
```json
"failedLetters":  {
                          "global":  [
                                         "bdc",
                                         "cdc",
                                         "ddc",
                                         "hdc"
                                     ]
                      },
```